### PR TITLE
Replace GNU readline with linenoise

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ext/peelocpp-unicode"]
 	path = ext/peelocpp-unicode
 	url = git@github.com:peelonet/peelocpp-unicode.git
+[submodule "ext/linenoise"]
+	path = ext/linenoise
+	url = git@github.com:antirez/linenoise.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
-PROJECT(laskin CXX)
+PROJECT(laskin C CXX)
 
 SET(CMAKE_CXX_STANDARD 17)
 
@@ -13,11 +13,6 @@ FIND_PATH(
   NAMES gmpxx.h
   DOC "The directory containing GMPXX include files."
 )
-FIND_PATH(
-  READLINE_INCLUDE_DIR
-  NAMES readline/readline.h
-  DOC "The directory containing readline include files."
-)
 FIND_LIBRARY(
   GMP_LIBRARIES
   NAMES gmp libgmp
@@ -28,28 +23,21 @@ FIND_LIBRARY(
   NAMES gmpxx libgmpxx
   DOC "Path to the GMPXX library."
 )
-FIND_LIBRARY(
-  READLINE_LIBRARIES
-  NAMES readline
-  DOC "Path to the readline library."
-)
 IF(NOT GMP_LIBRARIES OR NOT GMPXX_LIBRARIES)
   MESSAGE(FATAL_ERROR "Could not find GMPXX library.")
-ENDIF()
-IF(NOT READLINE_LIBRARIES)
-  MESSAGE(FATAL_ERROR "Could not find readline library.")
 ENDIF()
 
 INCLUDE_DIRECTORIES(
   ${GMP_INCLUDE_DIR}
   ${GMPXX_INCLUDE_DIR}
-  ${READLINE_INCLUDE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/ext/linenoise
   ${CMAKE_CURRENT_SOURCE_DIR}/ext/peelocpp-unicode/include
 )
 
 SET(
   COMMON_SOURCES
+  ext/linenoise/linenoise.c
   ext/peelocpp-unicode/src/convert.cpp
   ext/peelocpp-unicode/src/test.cpp
   ext/peelocpp-unicode/src/utf8.cpp
@@ -86,7 +74,6 @@ TARGET_LINK_LIBRARIES(
   laskin
   ${GMP_LIBRARIES}
   ${GMPXX_LIBRARIES}
-  ${READLINE_LIBRARIES}
 )
 
 INSTALL(

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ inspired by [Forth], [RPL] and [Plorth].
 ## Requirements
 
 * [GNU Multiple Precision Arithmetic Library]
-* [GNU Readline]
 * [CMake]
 * C++17 compatible C++ compiler
+
+Other dependencies already included in the source code repository as Git
+submodules:
+
+* [linenoise]
+* [peelocpp-unicode]
 
 ## How to compile
 
@@ -20,5 +25,6 @@ mkdir build && cd build && cmake .. && make
 [RPL]: https://en.wikipedia.org/wiki/RPL_(programming_language)
 [Plorth]: https://plorth.org
 [GNU Multiple Precision Arithmetic Library]: https://gmplib.org/
-[GNU Readline]: https://tiswww.case.edu/php/chet/readline/rltop.html<Paste>
 [CMake]: https://cmake.org/
+[linenoise]: https://github.com/antirez/linenoise
+[peelocpp-unicode]: https://github.com/peelonet/peelocpp-unicode

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -27,8 +27,7 @@
 #include <cstring>
 #include <stack>
 
-#include <readline/readline.h>
-#include <readline/history.h>
+#include <linenoise.h>
 #include <peelo/unicode.hpp>
 
 #include "laskin/context.hpp"
@@ -49,20 +48,20 @@ namespace laskin
 
   void run_repl(class context& context)
   {
-    char* line;
     std::u32string source;
 
-    while ((line = ::readline(get_prompt(context))) != nullptr)
+    while (auto line = ::linenoise(get_prompt(context)))
     {
       if (!*line)
       {
+        ::linenoiseFree(line);
         continue;
       }
-      ::add_history(line);
+      ::linenoiseHistoryAdd(line);
       source.append(peelo::unicode::utf8::decode(line));
       source.append(1, '\n');
       count_open_braces(open_braces, line);
-      std::free(line);
+      ::linenoiseFree(line);
       if (!open_braces.empty())
       {
         continue;


### PR DESCRIPTION
Linenoise is very small and easy to embed GNU readline replacement,
which provides all the features I need to for CLI REPL of Laskin. Ditch
GNU readline and use linenoise instead, since I am already running into
weird segmentation faults because of readline library and I am too lazy
to try to debug third party libraries.