### PR TITLE
Redesign how value class works

### DIFF
--- a/2cpp/src/instruction.cpp
+++ b/2cpp/src/instruction.cpp
@@ -75,10 +75,10 @@ namespace laskin2cpp
     const struct options& options
   ) const
   {
-    if (options.number_optimization && peelo::number::is_valid(id))
+    if (options.number_optimization && laskin::number::is_valid(id))
     {
       writer.print("c.push(");
-      transpile_number(peelo::number::parse(id), writer);
+      transpile_number(laskin::number::parse(id), writer);
       writer.println(");");
     } else {
       writer.println("c.lookup(" + writer::escape(id) + ", &std::cout);");

--- a/2cpp/src/transpile.cpp
+++ b/2cpp/src/transpile.cpp
@@ -33,36 +33,32 @@ namespace laskin2cpp
   static void
   transpile_boolean(bool value, class writer& writer)
   {
-    writer.print("value::make_boolean(");
     writer.print(value ? "true" : "false");
+  }
+
+  static void
+  transpile_date(const laskin::date& value, class writer& writer)
+  {
+    writer.print("date(");
+    writer.print(std::to_string(value.year()));
+    writer.print(", static_cast<month>(");
+    writer.print(std::to_string(static_cast<int>(value.month())));
+    writer.print("), ");
+    writer.print(std::to_string(value.day()));
     writer.print(")");
   }
 
   static void
-  transpile_date(const peelo::chrono::date& value, class writer& writer)
+  transpile_month(const laskin::month value, class writer& writer)
   {
-    writer.print("value::make_date(peelo::chrono::date(");
-    writer.print(std::to_string(value.year()));
-    writer.print(", static_cast<peelo::chrono::month>(");
-    writer.print(std::to_string(static_cast<int>(value.month())));
-    writer.print("), ");
-    writer.print(std::to_string(value.day()));
-    writer.print("))");
-  }
-
-  static void
-  transpile_month(const peelo::chrono::month value, class writer& writer)
-  {
-    writer.print("value::make_month(static_cast<peelo::chrono::month>(");
+    writer.print("static_cast<month>(");
     writer.print(std::to_string(static_cast<int>(value)));
-    writer.print("))");
+    writer.print(")");
   }
 
   void
-  transpile_number(const peelo::number& value, class writer& writer)
+  transpile_number(const laskin::number& value, class writer& writer)
   {
-    writer.print("value::make_number(");
-
     // If the number does not have measurement unit, see if it fits into
     // `double`.
     if (!value.measurement_unit())
@@ -84,6 +80,7 @@ namespace laskin2cpp
       }
       if (fits)
       {
+        writer.print("number(");
         writer.print(std::to_string(result));
         writer.print(")");
         return;
@@ -91,7 +88,7 @@ namespace laskin2cpp
     }
 
     // TODO: Find out more optimal way of converting measurement unit into C++.
-    writer.print("\"");
+    writer.print("value::parse_number(\"");
     writer.print(value.to_string());
     writer.print("\")");
   }
@@ -106,7 +103,7 @@ namespace laskin2cpp
     program subprogram;
 
     subprogram.compile(value, options);
-    writer.println("value::make_quote(quote(");
+    writer.println("quote(");
     writer.indent();
     writer.println("[](context& c, std::ostream* out)");
     writer.println("{");
@@ -118,17 +115,17 @@ namespace laskin2cpp
     writer.dedent();
     writer.println("}");
     writer.dedent();
-    writer.print("))");
+    writer.print(")");
   }
 
   static void
   transpile_record(
-    const laskin::value::record_container& value,
+    const laskin::record& value,
     class writer& writer,
     const struct options& options
   )
   {
-    writer.println("value::make_record({");
+    writer.println("record{");
     writer.indent();
     for (const auto& property : value)
     {
@@ -139,37 +136,35 @@ namespace laskin2cpp
       writer.println(" },");
     }
     writer.dedent();
-    writer.print("})");
+    writer.print("}");
   }
 
   static void
   transpile_string(const std::u32string& value, class writer& writer)
   {
-    writer.print("value::make_string(");
     writer.print(writer::escape(value));
-    writer.print(")");
   }
 
   static void
-  transpile_time(const peelo::chrono::time& value, class writer& writer)
+  transpile_time(const laskin::time& value, class writer& writer)
   {
-    writer.print("value::make_time(peelo::chrono::time(");
+    writer.print("time(");
     writer.print(std::to_string(value.hour()));
     writer.print(", ");
     writer.print(std::to_string(value.hour()));
     writer.print(", ");
     writer.print(std::to_string(value.minute()));
-    writer.print("))");
+    writer.print(")");
   }
 
   static void
   transpile_vector(
-    const laskin::value::vector_container& value,
+    const laskin::vector& value,
     class writer& writer,
     const struct options& options
   )
   {
-    writer.println("value::make_vector({");
+    writer.println("vector{");
     writer.indent();
     for (const auto& element : value)
     {
@@ -177,15 +172,15 @@ namespace laskin2cpp
       writer.println(",");
     }
     writer.dedent();
-    writer.print("})");
+    writer.print("}");
   }
 
   static void
-  transpile_weekday(const peelo::chrono::weekday value, class writer& writer)
+  transpile_weekday(const laskin::weekday value, class writer& writer)
   {
-    writer.print("value::make_weekday(static_cast<peelo::chrono::weekday>(");
+    writer.print("static_cast<weekday>(");
     writer.print(std::to_string(static_cast<int>(value)));
-    writer.print("))");
+    writer.print(")");
   }
 
   void
@@ -246,7 +241,7 @@ namespace laskin2cpp
     const struct options& options
   )
   {
-    writer.println("value::make_record({");
+    writer.println("{");
     writer.indent();
     for (const auto& property : properties)
     {
@@ -257,7 +252,7 @@ namespace laskin2cpp
       writer.println(" },");
     }
     writer.dedent();
-    writer.print("})");
+    writer.print("}");
   }
 
   static void
@@ -267,7 +262,7 @@ namespace laskin2cpp
     const struct options& options
   )
   {
-    writer.println("value::make_vector({");
+    writer.println("{");
     writer.indent();
     for (const auto& element : elements)
     {
@@ -275,7 +270,7 @@ namespace laskin2cpp
       writer.println(",");
     }
     writer.dedent();
-    writer.print("})");
+    writer.print("}");
   }
 
   void
@@ -321,9 +316,9 @@ namespace laskin2cpp
           const auto id
             = std::static_pointer_cast<laskin::node::symbol>(node)->id;
 
-          if (options.number_optimization && peelo::number::is_valid(id))
+          if (options.number_optimization && laskin::number::is_valid(id))
           {
-            transpile_number(peelo::number::parse(id), writer);
+            transpile_number(laskin::number::parse(id), writer);
           } else {
             writer.print("c.eval(" + writer::escape(id) + ")");
           }

--- a/2cpp/src/transpile.cpp
+++ b/2cpp/src/transpile.cpp
@@ -262,7 +262,7 @@ namespace laskin2cpp
     const struct options& options
   )
   {
-    writer.println("{");
+    writer.println("vector{");
     writer.indent();
     for (const auto& element : elements)
     {

--- a/2cpp/src/transpile.hpp
+++ b/2cpp/src/transpile.hpp
@@ -33,7 +33,7 @@
 namespace laskin2cpp
 {
   void transpile_number(
-    const peelo::number& value,
+    const laskin::number& value,
     class writer& writer
   );
 

--- a/2cpp/src/writer.hpp
+++ b/2cpp/src/writer.hpp
@@ -25,7 +25,7 @@
  */
 #pragma once
 
-#include <iostream>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/laskin/include/laskin/chrono.hpp
+++ b/laskin/include/laskin/chrono.hpp
@@ -25,10 +25,7 @@
  */
 #pragma once
 
-#include <peelo/chrono/date.hpp>
-#include <peelo/chrono/month.hpp>
-#include <peelo/chrono/time.hpp>
-#include <peelo/chrono/weekday.hpp>
+#include "./types.hpp"
 
 namespace laskin
 {
@@ -56,21 +53,21 @@ namespace laskin
    * Parses given string into a date. The date is expected to be in ISO 8601
    * format.
    */
-  peelo::chrono::date parse_date(const std::u32string&);
+  date parse_date(const std::u32string&);
 
   /**
    * Parses given string into a time. The time is expected to be in ISO 8601
    * format.
    */
-  peelo::chrono::time parse_time(const std::u32string&);
+  time parse_time(const std::u32string&);
 
   /**
    * Parses given string into a month.
    */
-  peelo::chrono::month parse_month(const std::u32string&);
+  month parse_month(const std::u32string&);
 
   /**
    * Parses given string into day of an week.
    */
-  peelo::chrono::weekday parse_weekday(const std::u32string&);
+  weekday parse_weekday(const std::u32string&);
 }

--- a/laskin/include/laskin/context.hpp
+++ b/laskin/include/laskin/context.hpp
@@ -149,88 +149,88 @@ namespace laskin
     /**
      * Pushes given value onto the stack.
      */
-    void push(const class value& value);
+    inline void push(const class value& value)
+    {
+      data.push_back(value);
+    }
 
     /**
      * Clears the entire data stack.
      */
-    void clear();
+    inline void clear()
+    {
+      data.clear();
+    }
 
     /**
      * Pushes given value onto the stack.
      */
-    context& operator<<(const class value& value);
+    inline context& operator<<(const class value& value)
+    {
+      data.push_back(value);
 
-    /**
-     * Pushes given boolean value onto the stack.
-     */
-    context& operator<<(bool value);
-
-    /**
-     * Pushes given numeric value onto the stack.
-     */
-    context& operator<<(const peelo::number& value);
-
-    /**
-     * Pushes given numeric value onto the stack.
-     */
-    context& operator<<(double value);
-
-    /**
-     * Pushes given numeric value onto the stack.
-     */
-    context& operator<<(int value);
-
-    /**
-     * Pushes given string onto the stack.
-     */
-    context& operator<<(const std::u32string& value);
-
-    /**
-     * Pushes given string onto the stack. The string is expected to be UTF-8
-     * encoded.
-     */
-    context& operator<<(const std::string& value);
-
-    /**
-     * Pushes given quote onto the stack.
-     */
-    context& operator<<(const quote& value);
-
-    /**
-     * Pushes given vector onto the stack.
-     */
-    context& operator<<(const value::vector_container& elements);
-
-    /**
-     * Pushes given record onto the stack.
-     */
-    context& operator<<(const value::record_container& properties);
+      return *this;
+    }
 
     /**
      * Pops value from the stack and places it into given slot.
      */
-    context& operator>>(class value& value);
+    inline context& operator>>(class value& value)
+    {
+      value = pop();
+
+      return *this;
+    }
 
     /**
      * Pops boolean value from the stack and places it into given slot.
      */
-    context& operator>>(bool& value);
+    inline context& operator>>(bool& value)
+    {
+      value = pop().as_boolean();
+
+      return *this;
+    }
 
     /**
      * Pops numeric value from the stack and places it into given slot.
      */
-    context& operator>>(peelo::number& value);
+    inline context& operator>>(number& value)
+    {
+      value = pop().as_number();
+
+      return *this;
+    }
 
     /**
      * Pops numeric value from the stack and places it into given slot.
      */
-    context& operator>>(double& value);
+    inline context& operator>>(long& value)
+    {
+      value = long(pop());
+
+      return *this;
+    }
+
+    /**
+     * Pops numeric value from the stack and places it into given slot.
+     */
+    inline context& operator>>(double& value)
+    {
+      value = double(pop());
+
+      return *this;
+    }
 
     /**
      * Pops string from the stack and places it into given slot.
      */
-    context& operator>>(std::u32string& value);
+    inline context& operator>>(std::u32string& value)
+    {
+      value = pop().as_string();
+
+      return *this;
+    }
 
     /**
      * Pops string from the stack and places it into given slot after encoding
@@ -241,17 +241,32 @@ namespace laskin
     /**
      * Pops quote from the stack and places it into given slot.
      */
-    context& operator>>(quote& value);
+    inline context& operator>>(quote& value)
+    {
+      value = pop().as_quote();
+
+      return *this;
+    }
 
     /**
      * Pops vector from the stack and places it into given slot.
      */
-    context& operator>>(value::vector_container& elements);
+    inline context& operator>>(vector& elements)
+    {
+      elements = pop().as_vector();
+
+      return *this;
+    }
 
     /**
      * Pops record from the stack and places it into given slot.
      */
-    context& operator>>(value::record_container& properties);
+    inline context& operator>>(record& properties)
+    {
+      properties = pop().as_record();
+
+      return *this;
+    }
 
     /**
      * Returns `false` if the data stack is empty, `true` otherwise.

--- a/laskin/include/laskin/quote.hpp
+++ b/laskin/include/laskin/quote.hpp
@@ -70,17 +70,17 @@ namespace laskin
     /**
      * Constructs empty quote that does nothing.
      */
-    explicit quote();
+    quote();
 
     /**
      * Constructs native quote from given function callback.
      */
-    explicit quote(const callback& cb);
+    quote(const callback& cb);
 
     /**
      * Constructs scripted quote from given AST nodes.
      */
-    explicit quote(const node_container& nodes);
+    quote(const node_container& nodes);
 
     LASKIN_DEFAULT_COPY_AND_ASSIGN(quote);
 

--- a/laskin/include/laskin/types.hpp
+++ b/laskin/include/laskin/types.hpp
@@ -25,37 +25,31 @@
  */
 #pragma once
 
-#include <peelo/unicode/ctype/isspace.hpp>
+#include <string>
 
-#include "laskin/types.hpp"
+#include <peelo/chrono/date.hpp>
+#include <peelo/chrono/time.hpp>
+#include <peelo/number.hpp>
+#include <tsl/ordered_map.h>
 
-namespace laskin::utils
+namespace laskin
 {
-  /**
-   * Tests whether given string is blank or not. String is considered to be
-   * blank when it's either empty or contains only whitespace characters.
-   */
-  template<class T>
-  inline bool is_blank(const std::basic_string<T>& str)
-  {
-    const auto length = str.length();
+  class context;
+  class node;
+  class quote;
+  class value;
 
-    if (!length)
-    {
-      return true;
-    }
-    for (std::size_t i = 0; i < length; ++i)
-    {
-      if (!peelo::unicode::ctype::isspace(str[i]))
-      {
-        return false;
-      }
-    }
+  using number = peelo::number;
 
-    return true;
-  }
+  using date = peelo::chrono::date;
 
-  std::int64_t time_as_seconds(const time& time);
+  using month = peelo::chrono::month;
 
-  std::u32string escape_string(const std::u32string& str);
+  using time = peelo::chrono::time;
+
+  using weekday = peelo::chrono::weekday;
+
+  using vector = std::vector<value>;
+
+  using record = tsl::ordered_map<std::u32string, value>;
 }

--- a/laskin/include/laskin/value.hpp
+++ b/laskin/include/laskin/value.hpp
@@ -26,27 +26,17 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 
-#include <peelo/chrono/date.hpp>
-#include <peelo/chrono/time.hpp>
-#include <peelo/number.hpp>
-#include <tsl/ordered_map.h>
+#include "laskin/types.hpp"
 
 namespace laskin
 {
-  class node;
-  class quote;
-
   /**
    * Wrapper class for supported value types.
    */
   class value
   {
   public:
-    using vector_container = std::vector<value>;
-    using record_container = tsl::ordered_map<std::u32string, value>;
-
     /**
      * Enumeration of different supported value types.
      */
@@ -65,135 +55,84 @@ namespace laskin
     };
 
     /**
-     * Constructs boolean value.
-     */
-    static value make_boolean(bool value);
-
-    /**
-     * Constructs number value.
-     */
-    static value make_number(const peelo::number& value);
-
-    /**
-     * Constructs integer number value.
-     */
-    static value make_number(
-      int value,
-      const peelo::number::unit_type& unit = std::nullopt
-    );
-
-    /**
-     * Constructs integer number value.
-     */
-    static value make_number(
-      std::int64_t value,
-      const peelo::number::unit_type& unit = std::nullopt
-    );
-
-    /**
-     * Constructs real number value.
-     */
-    static value make_number(
-      double value,
-      const peelo::number::unit_type& unit = std::nullopt
-    );
-
-    /**
      * Constructs number value by parsing number and unit from given string.
      */
-    static value make_number(const std::u32string& input);
-
-    /**
-     * Constructs vector value.
-     */
-    static value make_vector(const vector_container& elements);
-
-    /**
-     * Constructs vector value from given iterator.
-     */
-    template<class InputIt>
-    static value make_vector(InputIt first, InputIt last)
-    {
-      return make_vector(vector_container(first, last));
-    }
-
-    /**
-     * Constructs string value.
-     */
-    static value make_string(const std::u32string& string);
-
-    /**
-     * Constructs string value from given iterator.
-     */
-    template<class InputIt>
-    static value make_string(InputIt first, InputIt last)
-    {
-      return make_string(std::u32string(first, last));
-    }
-
-    /**
-     * Constructs quote value.
-     */
-    static value make_quote(const class quote& quote);
-
-    /**
-     * Constructs quote from given sequence of nodes.
-     */
-    static value make_quote(const std::vector<std::shared_ptr<node>>& nodes);
-
-    /**
-     * Constructs month value.
-     */
-    static value make_month(peelo::chrono::month month);
-
-    /**
-     * Constructs month value from given string which should contain valid name
-     * of a month.
-     */
-    static value make_month(const std::u32string& month);
-
-    /**
-     * Constructs weekday value.
-     */
-    static value make_weekday(peelo::chrono::weekday weekday);
-
-    /**
-     * Constructs weekday value from given string which should contain valid name
-     * of weekday.
-     */
-    static value make_weekday(const std::u32string& weekday);
-
-    /**
-     * Constructs date value.
-     */
-    static value make_date(const peelo::chrono::date& date);
-
-    /**
-     * Constructs date value from given string. The input is expected to be in
-     * ISO 8601 format.
-     */
-    static value make_date(const std::u32string& input);
-
-    /**
-     * Constructs time value.
-     */
-    static value make_time(const peelo::chrono::time& time);
-
-    /**
-     * Constructs time value from given string. The input is expected to be in
-     * ISO 8601 format.
-     */
-    static value make_time(const std::u32string& input);
-
-    /**
-     * Constructs record value.
-     */
-    static value make_record(const record_container& properties);
+    static value parse_number(const std::u32string& input);
 
     /**
      * Constructs boolean value of false.
      */
     explicit value();
+
+    /**
+     * Constructs boolean value.
+     */
+    value(bool value);
+
+    /**
+     * Constructs numeric value.
+     */
+    value(const number& value);
+
+    /**
+     * Constructs numeric value.
+     */
+    value(int value);
+
+    /**
+     * Constructs numeric value.
+     */
+    value(long value);
+
+    /**
+     * Constructs numeric value.
+     */
+    value(double value);
+
+    /**
+     * Constructs string.
+     */
+    value(const std::u32string& value);
+
+    /**
+     * Constructs string. The input is expected to be encoded with UTF-8.
+     */
+    value(const std::string& value);
+
+    /**
+     * Constructs vector.
+     */
+    value(const vector& elements);
+
+    /**
+     * Constructs record.
+     */
+    value(const record& properties);
+
+    /**
+     * Constructs quote.
+     */
+    value(const quote& value);
+
+    /**
+     * Constructs date value.
+     */
+    value(const date& value);
+
+    /**
+     * Constructs time value.
+     */
+    value(const time& value);
+
+    /**
+     * Constructs month value.
+     */
+    value(month value);
+
+    /**
+     * Constructs day of the week value.
+     */
+    value(weekday value);
 
     /**
      * Constructs copy of existing value.
@@ -212,9 +151,183 @@ namespace laskin
     ~value();
 
     /**
+     * Assigns boolean value into this value.
+     */
+    value& assign(bool value);
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    value& assign(const number& value);
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    value& assign(int value);
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    value& assign(long value);
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    value& assign(double value);
+
+    /**
+     * Assigns string into this value.
+     */
+    value& assign(const std::u32string& value);
+
+    /**
+     * Assigns UTF-8 encoded into this value.
+     */
+    value& assign(const std::string& value);
+
+    /**
+     * Assigns vector into this value.
+     */
+    value& assign(const vector& elements);
+
+    /**
+     * Assigns record into this value.
+     */
+    value& assign(const record& properties);
+
+    /**
+     * Assigns quote into this value.
+     */
+    value& assign(const quote& value);
+
+    /**
+     * Assigns date value into this value.
+     */
+    value& assign(const date& value);
+
+    /**
+     * Assigns time value into this value.
+     */
+    value& assign(const time& value);
+
+    /**
+     * Assigns month value into this value.
+     */
+    value& assign(month value);
+
+    /**
+     * Assigns day of the week value into this value.
+     */
+    value& assign(weekday value);
+
+    /**
      * Copies contents of another value into this one.
      */
     value& assign(const value& that);
+
+    /**
+     * Assigns boolean value into this value.
+     */
+    inline value& operator=(bool value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    inline value& operator=(const number& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    inline value& operator=(int value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    inline value& operator=(long value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns numeric value into this value.
+     */
+    inline value& operator=(double value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns string into this value.
+     */
+    inline value& operator=(const std::u32string& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns UTF-8 encoded into this value.
+     */
+    inline value& operator=(const std::string& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns vector into this value.
+     */
+    inline value& operator=(const vector& elements)
+    {
+      return assign(elements);
+    }
+
+    /**
+     * Assigns record into this value.
+     */
+    inline value& operator=(const record& properties)
+    {
+      return assign(properties);
+    }
+
+    /**
+     * Assigns quote into this value.
+     */
+    inline value& operator=(const quote& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns date value into this value.
+     */
+    inline value& operator=(const date& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns time value into this value.
+     */
+    inline value& operator=(const time& value)
+    {
+      return assign(value);
+    }
+
+    /**
+     * Assigns day of the week value into this value.
+     */
+    inline value& operator=(weekday value)
+    {
+      return assign(value);
+    }
 
     /**
      * Copies contents of another value into this one.
@@ -256,15 +369,29 @@ namespace laskin
     void reset();
 
     bool as_boolean() const;
-    const peelo::number& as_number() const;
-    const vector_container& as_vector() const;
-    const record_container& as_record() const;
+    const number& as_number() const;
+    const vector& as_vector() const;
+    const record& as_record() const;
     const std::u32string& as_string() const;
     const quote& as_quote() const;
-    peelo::chrono::month as_month() const;
-    peelo::chrono::weekday as_weekday() const;
-    const peelo::chrono::date& as_date() const;
-    const peelo::chrono::time& as_time() const;
+    month as_month() const;
+    weekday as_weekday() const;
+    const date& as_date() const;
+    const time& as_time() const;
+
+    /**
+     * Extracts number value as long integer, or throws `laskin::error` if
+     * the value does not contain number value or does not fit into long
+     * integer.
+     */
+    explicit operator long() const;
+
+    /**
+     * Extracts number value as double precision, or throws `laskin::error` if
+     * the value does not contain number value or does not fit into double
+     * precision.
+     */
+    explicit operator double() const;
 
     /**
      * Constructs string representation of the value.
@@ -398,15 +525,15 @@ namespace laskin
     union
     {
       bool m_value_boolean;
-      peelo::number* m_value_number;
-      vector_container* m_value_vector;
+      number* m_value_number;
+      vector* m_value_vector;
       std::u32string* m_value_string;
       quote* m_value_quote;
-      peelo::chrono::month m_value_month;
-      peelo::chrono::weekday m_value_weekday;
-      peelo::chrono::date* m_value_date;
-      peelo::chrono::time* m_value_time;
-      record_container* m_value_record;
+      month m_value_month;
+      weekday m_value_weekday;
+      date* m_value_date;
+      time* m_value_time;
+      record* m_value_record;
     };
   };
 

--- a/laskin/src/api/date.cpp
+++ b/laskin/src/api/date.cpp
@@ -39,7 +39,7 @@ LASKIN_BUILTIN_WORD(w_today)
 {
   try
   {
-    context << value::make_date(peelo::chrono::date::today());
+    context << date::today();
   }
   catch (const std::runtime_error&)
   {
@@ -59,7 +59,7 @@ LASKIN_BUILTIN_WORD(w_tomorrow)
 {
   try
   {
-    context << value::make_date(peelo::chrono::date::tomorrow());
+    context << date::tomorrow();
   }
   catch (const std::runtime_error&)
   {
@@ -79,7 +79,7 @@ LASKIN_BUILTIN_WORD(w_yesterday)
 {
   try
   {
-    context << value::make_date(peelo::chrono::date::yesterday());
+    context << date::yesterday();
   }
   catch (const std::runtime_error&)
   {
@@ -107,7 +107,7 @@ LASKIN_BUILTIN_WORD(w_year)
  */
 LASKIN_BUILTIN_WORD(w_month)
 {
-  context << value::make_month(context.peek().as_date().month());
+  context << context.peek().as_date().month();
 }
 
 /**
@@ -127,7 +127,7 @@ LASKIN_BUILTIN_WORD(w_day)
  */
 LASKIN_BUILTIN_WORD(w_weekday)
 {
-  context << value::make_weekday(context.peek().as_date().day_of_week());
+  context << context.peek().as_date().day_of_week();
 }
 
 /**
@@ -193,9 +193,9 @@ LASKIN_BUILTIN_WORD(w_format)
  */
 LASKIN_BUILTIN_WORD(w_to_number)
 {
-  context << value::make_number(
+  context << number(
     context.pop().as_date().timestamp(),
-    peelo::number::unit::second
+    number::unit::second
   );
 }
 
@@ -208,15 +208,8 @@ LASKIN_BUILTIN_WORD(w_to_number)
 LASKIN_BUILTIN_WORD(w_to_vector)
 {
   const auto date = context.pop().as_date();
-  const auto year = date.year();
-  const auto month = date.month();
-  const auto day = date.day();
 
-  context << value::make_vector({
-    value::make_number(year),
-    value::make_month(month),
-    value::make_number(day)
-  });
+  context << vector{ date.year(), date.month(), date.day() };
 }
 
 namespace laskin::api

--- a/laskin/src/api/month.cpp
+++ b/laskin/src/api/month.cpp
@@ -35,7 +35,7 @@ using namespace laskin;
  */
 LASKIN_BUILTIN_WORD(w_january)
 {
-  context << value::make_month(peelo::chrono::month::jan);
+  context << month::jan;
 }
 
 /**
@@ -45,7 +45,7 @@ LASKIN_BUILTIN_WORD(w_january)
  */
 LASKIN_BUILTIN_WORD(w_february)
 {
-  context << value::make_month(peelo::chrono::month::feb);
+  context << month::feb;
 }
 
 /**
@@ -55,7 +55,7 @@ LASKIN_BUILTIN_WORD(w_february)
  */
 LASKIN_BUILTIN_WORD(w_march)
 {
-  context << value::make_month(peelo::chrono::month::mar);
+  context << month::mar;
 }
 
 /**
@@ -65,7 +65,7 @@ LASKIN_BUILTIN_WORD(w_march)
  */
 LASKIN_BUILTIN_WORD(w_april)
 {
-  context << value::make_month(peelo::chrono::month::apr);
+  context << month::apr;
 }
 
 /**
@@ -75,7 +75,7 @@ LASKIN_BUILTIN_WORD(w_april)
  */
 LASKIN_BUILTIN_WORD(w_may)
 {
-  context << value::make_month(peelo::chrono::month::may);
+  context << month::may;
 }
 
 /**
@@ -85,7 +85,7 @@ LASKIN_BUILTIN_WORD(w_may)
  */
 LASKIN_BUILTIN_WORD(w_june)
 {
-  context << value::make_month(peelo::chrono::month::jun);
+  context << month::jun;
 }
 
 /**
@@ -95,7 +95,7 @@ LASKIN_BUILTIN_WORD(w_june)
  */
 LASKIN_BUILTIN_WORD(w_july)
 {
-  context << value::make_month(peelo::chrono::month::jul);
+  context << month::jul;
 }
 
 /**
@@ -105,7 +105,7 @@ LASKIN_BUILTIN_WORD(w_july)
  */
 LASKIN_BUILTIN_WORD(w_august)
 {
-  context << value::make_month(peelo::chrono::month::aug);
+  context << month::aug;
 }
 
 /**
@@ -115,7 +115,7 @@ LASKIN_BUILTIN_WORD(w_august)
  */
 LASKIN_BUILTIN_WORD(w_september)
 {
-  context << value::make_month(peelo::chrono::month::sep);
+  context << month::sep;
 }
 
 /**
@@ -125,7 +125,7 @@ LASKIN_BUILTIN_WORD(w_september)
  */
 LASKIN_BUILTIN_WORD(w_october)
 {
-  context << value::make_month(peelo::chrono::month::oct);
+  context << month::oct;
 }
 
 /**
@@ -135,7 +135,7 @@ LASKIN_BUILTIN_WORD(w_october)
  */
 LASKIN_BUILTIN_WORD(w_november)
 {
-  context << value::make_month(peelo::chrono::month::nov);
+  context << month::nov;
 }
 
 /**
@@ -145,7 +145,7 @@ LASKIN_BUILTIN_WORD(w_november)
  */
 LASKIN_BUILTIN_WORD(w_december)
 {
-  context << value::make_month(peelo::chrono::month::dec);
+  context << month::dec;
 }
 
 /**

--- a/laskin/src/api/number.cpp
+++ b/laskin/src/api/number.cpp
@@ -57,7 +57,7 @@ LASKIN_BUILTIN_WORD(w_e)
  */
 LASKIN_BUILTIN_WORD(w_inf)
 {
-  context << peelo::number::inf();
+  context << number::inf();
 }
 
 /**
@@ -67,7 +67,7 @@ LASKIN_BUILTIN_WORD(w_inf)
  */
 LASKIN_BUILTIN_WORD(w_neg_inf)
 {
-  context << -peelo::number::inf();
+  context << -number::inf();
 }
 
 /**
@@ -77,7 +77,7 @@ LASKIN_BUILTIN_WORD(w_neg_inf)
  */
 LASKIN_BUILTIN_WORD(w_nan)
 {
-  context << peelo::number::nan();
+  context << number::nan();
 }
 
 /**
@@ -146,7 +146,7 @@ LASKIN_BUILTIN_WORD(w_drop_unit)
  */
 LASKIN_BUILTIN_WORD(w_is_inf)
 {
-  context << value::make_boolean(context.peek().as_number().is_inf());
+  context << context.peek().as_number().is_inf();
 }
 
 /**
@@ -156,7 +156,7 @@ LASKIN_BUILTIN_WORD(w_is_inf)
  */
 LASKIN_BUILTIN_WORD(w_is_nan)
 {
-  context << value::make_boolean(context.peek().as_number().is_nan());
+  context << context.peek().as_number().is_nan();
 }
 
 /**
@@ -170,12 +170,11 @@ LASKIN_BUILTIN_WORD(w_range)
 {
   const auto limit = context.pop().as_number();
   auto current = context.pop().as_number();
-  value::vector_container result;
+  vector result;
 
   while (current < limit)
   {
-    result.push_back(value::make_number(current));
-    ++current;
+    result.push_back(current++);
   }
   context << result;
 }
@@ -204,7 +203,7 @@ LASKIN_BUILTIN_WORD(w_times)
   auto count = context.pop().as_number();
   const auto quote = context.pop().as_quote();
 
-  if (count < peelo::number())
+  if (count < number())
   {
     count = -count;
   }
@@ -368,24 +367,13 @@ LASKIN_BUILTIN_WORD(w_rad)
  */
 LASKIN_BUILTIN_WORD(w_to_month)
 {
-  try
-  {
-    const auto value = long(context.pop().as_number());
+  const auto value = long(context.pop());
 
-    if (value < 1 || value > 12)
-    {
-      throw error(error::type::range, U"Month index out of range.");
-    }
-    context << value::make_month(static_cast<peelo::chrono::month>(value - 1));
-  }
-  catch (const std::underflow_error&)
+  if (value < 1 || value > 12)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    throw error(error::type::range, U"Month index out of range.");
   }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+  context << static_cast<month>(value - 1);
 }
 
 /**
@@ -398,24 +386,13 @@ LASKIN_BUILTIN_WORD(w_to_month)
  */
 LASKIN_BUILTIN_WORD(w_to_weekday)
 {
-  try
-  {
-    const auto value = long(context.pop().as_number());
+  const auto value = long(context.pop());
 
-    if (value < 1 || value > 7)
-    {
-      throw error(error::type::range, U"Weekday index out of range.");
-    }
-    context << value::make_weekday(static_cast<peelo::chrono::weekday>(value - 1));
-  }
-  catch (const std::underflow_error&)
+  if (value < 1 || value > 7)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    throw error(error::type::range, U"Weekday index out of range.");
   }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+  context << static_cast<weekday>(value - 1);
 }
 
 namespace laskin::api

--- a/laskin/src/api/quote.cpp
+++ b/laskin/src/api/quote.cpp
@@ -48,10 +48,10 @@ LASKIN_BUILTIN_WORD(w_compose)
   const auto left = context.pop().as_quote();
   const auto call = std::make_shared<node::symbol>(U"quote:call");
 
-  context << value::make_quote({
-    std::make_shared<node::literal>(value::make_quote(left)),
+  context << quote({
+    std::make_shared<node::literal>(left),
     call,
-    std::make_shared<node::literal>(value::make_quote(right)),
+    std::make_shared<node::literal>(right),
     call
   });
 }
@@ -63,12 +63,12 @@ LASKIN_BUILTIN_WORD(w_compose)
  */
 LASKIN_BUILTIN_WORD(w_curry)
 {
-  const auto quote = context.pop().as_quote();
+  const auto q = context.pop().as_quote();
   const auto argument = context.pop();
 
-  context << value::make_quote({
+  context << quote({
     std::make_shared<node::literal>(argument),
-    std::make_shared<node::literal>(value::make_quote(quote)),
+    std::make_shared<node::literal>(q),
     std::make_shared<node::symbol>(U"quote:call")
   });
 }
@@ -80,10 +80,10 @@ LASKIN_BUILTIN_WORD(w_curry)
  */
 LASKIN_BUILTIN_WORD(w_negate)
 {
-  const auto quote = context.pop().as_quote();
+  const auto q = context.pop().as_quote();
 
-  context << value::make_quote({
-    std::make_shared<node::literal>(value::make_quote(quote)),
+  context << quote({
+    std::make_shared<node::literal>(q),
     std::make_shared<node::symbol>(U"quote:call"),
     std::make_shared<node::symbol>(U"boolean:not")
   });

--- a/laskin/src/api/record.cpp
+++ b/laskin/src/api/record.cpp
@@ -37,7 +37,7 @@ LASKIN_BUILTIN_WORD(w_size)
 {
   const auto& properties = context.peek().as_record();
 
-  context << value::make_number(static_cast<std::int64_t>(properties.size()));
+  context << static_cast<long>(properties.size());
 }
 
 /**
@@ -48,12 +48,12 @@ LASKIN_BUILTIN_WORD(w_size)
 LASKIN_BUILTIN_WORD(w_keys)
 {
   const auto& properties = context.peek().as_record();
-  value::vector_container result;
+  vector result;
 
   result.reserve(properties.size());
   for (const auto& property : properties)
   {
-    result.push_back(value::make_string(property.first));
+    result.push_back(property.first);
   }
   context << result;
 }
@@ -66,7 +66,7 @@ LASKIN_BUILTIN_WORD(w_keys)
 LASKIN_BUILTIN_WORD(w_values)
 {
   const auto& properties = context.peek().as_record();
-  value::vector_container result;
+  vector result;
 
   result.reserve(properties.size());
   for (const auto& property : properties)
@@ -103,7 +103,7 @@ LASKIN_BUILTIN_WORD(w_map)
 {
   const auto properties = context.pop().as_record();
   const auto quote = context.pop().as_quote();
-  value::record_container new_properties;
+  record new_properties;
 
   for (const auto& property : properties)
   {
@@ -130,7 +130,7 @@ LASKIN_BUILTIN_WORD(w_filter)
 {
   const auto properties = context.pop().as_record();
   const auto quote = context.pop().as_quote();
-  value::record_container new_properties;
+  record new_properties;
 
   for (const auto& property : properties)
   {
@@ -190,17 +190,12 @@ LASKIN_BUILTIN_WORD(w_set)
 LASKIN_BUILTIN_WORD(w_to_vector)
 {
   const auto properties = context.pop().as_record();
-  value::vector_container values;
+  vector values;
 
   values.reserve(properties.size());
   for (const auto& property : properties)
   {
-    value::vector_container pair;
-
-    pair.reserve(2);
-    pair.push_back(value::make_string(property.first));
-    pair.push_back(property.second);
-    values.push_back(value::make_vector(pair));
+    values.push_back(vector{ property.first, property.second });
   }
 
   context << values;

--- a/laskin/src/api/string.cpp
+++ b/laskin/src/api/string.cpp
@@ -41,9 +41,7 @@ using namespace laskin;
  */
 LASKIN_BUILTIN_WORD(w_length)
 {
-  context << value::make_number(
-    static_cast<std::int64_t>(context.peek().as_string().length())
-  );
+  context << static_cast<long>(context.peek().as_string().length());
 }
 
 /**
@@ -55,12 +53,12 @@ LASKIN_BUILTIN_WORD(w_length)
 LASKIN_BUILTIN_WORD(w_chars)
 {
   const auto str = context.peek().as_string();
-  value::vector_container result;
+  vector result;
 
   result.reserve(str.length());
   for (const auto& c : str)
   {
-    result.push_back(value::make_string(std::u32string(&c, 1)));
+    result.push_back(std::u32string(&c, 1));
   }
   context << result;
 }
@@ -74,12 +72,12 @@ LASKIN_BUILTIN_WORD(w_chars)
 LASKIN_BUILTIN_WORD(w_runes)
 {
   const auto str = context.peek().as_string();
-  value::vector_container result;
+  vector result;
 
   result.reserve(str.length());
   for (const auto& c : str)
   {
-    result.push_back(value::make_number(static_cast<std::int64_t>(c)));
+    result.push_back(static_cast<long>(c));
   }
   context << result;
 }
@@ -96,7 +94,7 @@ LASKIN_BUILTIN_WORD(w_words)
   const auto length = str.length();
   std::u32string::size_type begin = 0;
   std::u32string::size_type end = 0;
-  value::vector_container result;
+  vector result;
 
   for (std::u32string::size_type i = 0; i < length; ++i)
   {
@@ -104,7 +102,7 @@ LASKIN_BUILTIN_WORD(w_words)
     {
       if (end - begin > 0)
       {
-        result.push_back(value::make_string(str.substr(begin, end - begin)));
+        result.push_back(str.substr(begin, end - begin));
       }
       begin = end = i + 1;
     } else {
@@ -113,7 +111,7 @@ LASKIN_BUILTIN_WORD(w_words)
   }
   if (end - begin > 0)
   {
-    result.push_back(value::make_string(str.substr(begin, end - begin)));
+    result.push_back(str.substr(begin, end - begin));
   }
   context << result;
 }
@@ -129,7 +127,7 @@ LASKIN_BUILTIN_WORD(w_lines)
   const auto length = str.length();
   std::u32string::size_type begin = 0;
   std::u32string::size_type end = 0;
-  value::vector_container result;
+  vector result;
 
   for (std::u32string::size_type i = 0; i < length; ++i)
   {
@@ -137,12 +135,12 @@ LASKIN_BUILTIN_WORD(w_lines)
 
     if (i + 1 < length && c == '\r' && str[i + 1] == '\n')
     {
-      result.push_back(value::make_string(str.substr(begin, end - begin)));
+      result.push_back(str.substr(begin, end - begin));
       begin = end = ++i + 1;
     }
     else if (c == '\n' || c == '\r')
     {
-      result.push_back(value::make_string(str.substr(begin, end - begin)));
+      result.push_back(str.substr(begin, end - begin));
       begin = end = i + 1;
     } else {
       ++end;
@@ -150,7 +148,7 @@ LASKIN_BUILTIN_WORD(w_lines)
   }
   if (end - begin > 0)
   {
-    result.push_back(value::make_string(str.substr(begin, end - begin)));
+    result.push_back(str.substr(begin, end - begin));
   }
   context << result;
 }
@@ -274,7 +272,7 @@ LASKIN_BUILTIN_WORD(w_index_of)
   }
   else if (!substring_length)
   {
-    context << 0;
+    context << static_cast<int>(0);
     return;
   }
 
@@ -285,7 +283,7 @@ LASKIN_BUILTIN_WORD(w_index_of)
     return;
   }
 
-  context << value::make_number(static_cast<std::int64_t>(position));
+  context << static_cast<long>(position);
 }
 
 /**
@@ -309,7 +307,7 @@ LASKIN_BUILTIN_WORD(w_last_index_of)
   }
   else if (!substring_length)
   {
-    context << 0;
+    context << static_cast<int>(0);
     return;
   }
 
@@ -320,7 +318,7 @@ LASKIN_BUILTIN_WORD(w_last_index_of)
     return;
   }
 
-  context << value::make_number(static_cast<std::int64_t>(position));
+  context << static_cast<long>(position);
 }
 
 /**
@@ -332,7 +330,7 @@ LASKIN_BUILTIN_WORD(w_reverse)
 {
   const auto string = context.pop().as_string();
 
-  context << value::make_string(string.rbegin(), string.rend());
+  context << std::u32string(string.rbegin(), string.rend());
 }
 
 static void
@@ -485,40 +483,29 @@ LASKIN_BUILTIN_WORD(w_trim_end)
  */
 LASKIN_BUILTIN_WORD(w_substring)
 {
-  try
-  {
-    const auto string = context.pop().as_string();
-    const auto length = string.length();
-    auto begin = long(context.pop().as_number());
-    auto end = long(context.pop().as_number());
+  const auto string = context.pop().as_string();
+  const auto length = string.length();
+  auto begin = long(context.pop());
+  auto end = long(context.pop());
 
-    if (begin < 0)
-    {
-      begin += length;
-    }
-    if (end < 0)
-    {
-      end += length;
-    }
-
-    if (
-      (begin < 0 || begin >= static_cast<std::int64_t>(length)) ||
-        (end < 0 || end >= static_cast<std::int64_t>(length)) ||
-        end < begin)
-    {
-      throw error(error::type::range, U"String index out of bounds.");
-    }
-
-    context << string.substr(begin, end - begin + 1);
-  }
-  catch (const std::underflow_error&)
+  if (begin < 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    begin += length;
   }
-  catch (const std::overflow_error&)
+  if (end < 0)
   {
-    throw error(error::type::range, U"Numeric overflow.");
+    end += length;
   }
+
+  if (
+    (begin < 0 || begin >= static_cast<std::int64_t>(length)) ||
+      (end < 0 || end >= static_cast<std::int64_t>(length)) ||
+      end < begin)
+  {
+    throw error(error::type::range, U"String index out of bounds.");
+  }
+
+  context << string.substr(begin, end - begin + 1);
 }
 
 /**
@@ -533,7 +520,7 @@ LASKIN_BUILTIN_WORD(w_split)
   const auto pattern = context.pop().as_string();
   const auto string_length = string.length();
   const auto pattern_length = pattern.length();
-  value::vector_container result;
+  vector result;
 
   if (pattern_length)
   {
@@ -544,9 +531,11 @@ LASKIN_BUILTIN_WORD(w_split)
     {
       bool found = true;
 
-      for (std::u32string::size_type j = 0;
-            j < pattern_length && i + j < string_length;
-            ++j)
+      for (
+        std::u32string::size_type j = 0;
+        j < pattern_length && i + j < string_length;
+        ++j
+      )
       {
         if (pattern[j] != string[i + j])
         {
@@ -556,9 +545,7 @@ LASKIN_BUILTIN_WORD(w_split)
       }
       if (found)
       {
-        result.push_back(
-          value::make_string(string.substr(begin, end - begin))
-        );
+        result.push_back(string.substr(begin, end - begin));
         begin = end = i + 1;
       } else {
         ++end;
@@ -566,15 +553,13 @@ LASKIN_BUILTIN_WORD(w_split)
     }
     if (end - begin > 0)
     {
-      result.push_back(
-        value::make_string(string.substr(begin, end - begin))
-      );
+      result.push_back(string.substr(begin, end - begin));
     }
   } else {
     result.reserve(string_length);
     for (std::u32string::size_type i = 0; i < string_length; ++i)
     {
-      result.push_back(value::make_string(std::u32string(&string[i], 1)));
+      result.push_back(std::u32string(&string[i], 1));
     }
   }
 
@@ -588,28 +573,17 @@ LASKIN_BUILTIN_WORD(w_split)
  */
 LASKIN_BUILTIN_WORD(w_repeat)
 {
-  try
-  {
-    const auto string = context.pop().as_string();
-    auto count = long(context.pop().as_number());
-    std::u32string result;
+  const auto string = context.pop().as_string();
+  auto count = long(context.pop());
+  std::u32string result;
 
-    result.reserve(string.length() * count);
-    while (count > 0)
-    {
-      result.append(string);
-      --count;
-    }
-    context << result;
-  }
-  catch (const std::underflow_error&)
+  result.reserve(string.length() * count);
+  while (count > 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    result.append(string);
+    --count;
   }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+  context << result;
 }
 
 /**
@@ -659,42 +633,31 @@ LASKIN_BUILTIN_WORD(w_replace)
  */
 LASKIN_BUILTIN_WORD(w_pad_start)
 {
-  try
-  {
-    const auto string = context.pop().as_string();
-    auto pad_string = context.pop().as_string();
-    auto target_length = long(context.pop().as_number());
-    const auto string_length = string.length();
-    const auto pad_string_length = pad_string.length();
+  const auto string = context.pop().as_string();
+  auto pad_string = context.pop().as_string();
+  auto target_length = long(context.pop());
+  const auto string_length = string.length();
+  const auto pad_string_length = pad_string.length();
 
-    if (static_cast<long>(string_length) >= target_length)
+  if (static_cast<long>(string_length) >= target_length)
+  {
+    context << string;
+    return;
+  }
+
+  target_length -= string_length;
+  if (target_length > static_cast<long>(pad_string_length))
+  {
+    const auto original_pad_string = pad_string;
+    auto count = target_length / pad_string_length;
+
+    while (count-- > 0)
     {
-      context << string;
-      return;
+      pad_string += original_pad_string;
     }
-
-    target_length -= string_length;
-    if (target_length > static_cast<long>(pad_string_length))
-    {
-      const auto original_pad_string = pad_string;
-      auto count = target_length / pad_string_length;
-
-      while (count-- > 0)
-      {
-        pad_string += original_pad_string;
-      }
-    }
-
-    context << (pad_string.substr(0, target_length) + string);
   }
-  catch (const std::underflow_error&)
-  {
-    throw error(error::type::range, U"Numeric underflow.");
-  }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+
+  context << (pad_string.substr(0, target_length) + string);
 }
 
 /**
@@ -705,42 +668,31 @@ LASKIN_BUILTIN_WORD(w_pad_start)
  */
 LASKIN_BUILTIN_WORD(w_pad_end)
 {
-  try
-  {
-    const auto string = context.pop().as_string();
-    auto pad_string = context.pop().as_string();
-    auto target_length = long(context.pop().as_number());
-    const auto string_length = string.length();
-    const auto pad_string_length = pad_string.length();
+  const auto string = context.pop().as_string();
+  auto pad_string = context.pop().as_string();
+  auto target_length = long(context.pop());
+  const auto string_length = string.length();
+  const auto pad_string_length = pad_string.length();
 
-    if (static_cast<long>(string_length) >= target_length)
+  if (static_cast<long>(string_length) >= target_length)
+  {
+    context << string;
+    return;
+  }
+
+  target_length -= string_length;
+  if (target_length > static_cast<long>(pad_string_length))
+  {
+    const auto original_pad_string = pad_string;
+    auto count = target_length / pad_string_length;
+
+    while (count-- > 0)
     {
-      context << string;
-      return;
+      pad_string += original_pad_string;
     }
-
-    target_length -= string_length;
-    if (target_length > static_cast<long>(pad_string_length))
-    {
-      const auto original_pad_string = pad_string;
-      auto count = target_length / pad_string_length;
-
-      while (count-- > 0)
-      {
-        pad_string += original_pad_string;
-      }
-    }
-
-    context << (string + pad_string.substr(0, target_length));
   }
-  catch (const std::underflow_error&)
-  {
-    throw error(error::type::range, U"Numeric underflow.");
-  }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+
+  context << (string + pad_string.substr(0, target_length));
 }
 
 /**
@@ -753,32 +705,21 @@ LASKIN_BUILTIN_WORD(w_pad_end)
  */
 LASKIN_BUILTIN_WORD(w_at)
 {
-  try
-  {
-    const auto string = context.pop().as_string();
-    const auto length = string.length();
-    auto index = long(context.pop().as_number());
-    char32_t c;
+  const auto string = context.pop().as_string();
+  const auto length = string.length();
+  auto index = long(context.pop());
+  char32_t c;
 
-    if (index < 0)
-    {
-      index += length;
-    }
-    if (!length || index < 0 || index >= static_cast<long>(length))
-    {
-      throw error(error::type::range, U"String index out of bounds.");
-    }
-    c = string[index];
-    context << std::u32string(&c, 1);
-  }
-  catch (const std::underflow_error&)
+  if (index < 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    index += length;
   }
-  catch (const std::overflow_error&)
+  if (!length || index < 0 || index >= static_cast<long>(length))
   {
-    throw error(error::type::range, U"Numeric overflow.");
+    throw error(error::type::range, U"String index out of bounds.");
   }
+  c = string[index];
+  context << std::u32string(&c, 1);
 }
 
 /**
@@ -792,17 +733,7 @@ LASKIN_BUILTIN_WORD(w_to_number)
 {
   const auto string = context.pop().as_string();
 
-  try
-  {
-    context << peelo::number::parse(string);
-  }
-  catch (const std::invalid_argument&)
-  {
-    throw error(
-      error::type::range,
-      U"Cannot convert given string into a number."
-    );
-  }
+  context << value::parse_number(string);
 }
 
 /**

--- a/laskin/src/api/time.cpp
+++ b/laskin/src/api/time.cpp
@@ -39,7 +39,7 @@ LASKIN_BUILTIN_WORD(w_now)
 {
   try
   {
-    context << value::make_time(peelo::chrono::time::now());
+    context << time::now();
   }
   catch (const std::runtime_error&)
   {
@@ -103,7 +103,7 @@ LASKIN_BUILTIN_WORD(w_format)
 LASKIN_BUILTIN_WORD(w_to_number)
 {
   const auto time = context.pop().as_time();
-  peelo::number result(0.0, peelo::number::unit::second);
+  number result(0.0, number::unit::second);
 
   result += time.hour() * peelo::chrono::duration::seconds_per_hour;
   result += time.minute() * peelo::chrono::duration::seconds_per_minute;
@@ -122,11 +122,7 @@ LASKIN_BUILTIN_WORD(w_to_vector)
 {
   const auto time = context.pop().as_time();
 
-  context << value::make_vector({
-    value::make_number(time.hour()),
-    value::make_number(time.minute()),
-    value::make_number(time.second())
-  });
+  context << vector{ time.hour(), time.minute(), time.second() };
 }
 
 namespace laskin::api

--- a/laskin/src/api/utils.cpp
+++ b/laskin/src/api/utils.cpp
@@ -384,9 +384,7 @@ LASKIN_BUILTIN_WORD(w_tuck)
  */
 LASKIN_BUILTIN_WORD(w_depth)
 {
-  context << value::make_number(
-    static_cast<std::int64_t>(context.data.size())
-  );
+  context << static_cast<long>(context.data.size());
 }
 
 /**
@@ -662,12 +660,12 @@ LASKIN_BUILTIN_WORD(w_delete)
 LASKIN_BUILTIN_WORD(w_symbols)
 {
   const auto& dictionary = context.dictionary;
-  value::vector_container result;
+  vector result;
 
   result.reserve(dictionary.size());
   for (const auto& entry : dictionary)
   {
-    result.push_back(value::make_string(entry.first));
+    result.push_back(entry.first);
   }
   context << result;
 }

--- a/laskin/src/api/vector.cpp
+++ b/laskin/src/api/vector.cpp
@@ -36,26 +36,14 @@ using namespace laskin;
 LASKIN_BUILTIN_WORD(w_vector)
 {
   const auto size = context.pop().as_number();
-  value::vector_container elements;
+  vector elements;
 
-  try
-  {
-    elements.reserve(long(size));
-  }
-  catch (const std::underflow_error&)
-  {
-    throw error(error::type::range, U"Numeric underflow.");
-  }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
-  for (peelo::number i; i < size; ++i)
+  elements.reserve(long(size));
+  for (number i; i < size; ++i)
   {
     elements.push_back(context.pop());
   }
-
-  context << value::make_vector(elements.rbegin(), elements.rend());
+  context << vector(elements.rbegin(), elements.rend());
 }
 
 /**
@@ -65,9 +53,7 @@ LASKIN_BUILTIN_WORD(w_vector)
  */
 LASKIN_BUILTIN_WORD(w_length)
 {
-  context << value::make_number(
-    static_cast<std::int64_t>(context.peek().as_vector().size())
-  );
+  context << static_cast<long>(context.peek().as_vector().size());
 }
 
 /**
@@ -86,7 +72,7 @@ LASKIN_BUILTIN_WORD(w_max)
   {
     auto largest = vec[0];
 
-    for (value::vector_container::size_type i = 1; i < size; ++i)
+    for (vector::size_type i = 1; i < size; ++i)
     {
       const auto& candidate = vec[i];
 
@@ -118,7 +104,7 @@ LASKIN_BUILTIN_WORD(w_min)
   {
     auto smallest = vec[0];
 
-    for (value::vector_container::size_type i = 1; i < size; ++i)
+    for (vector::size_type i = 1; i < size; ++i)
     {
       const auto& candidate = vec[i];
 
@@ -150,7 +136,7 @@ LASKIN_BUILTIN_WORD(w_mean)
   {
     auto sum = vec[0].as_number();
 
-    for (value::vector_container::size_type i = 1; i < size; ++i)
+    for (vector::size_type i = 1; i < size; ++i)
     {
       sum = sum + vec[i].as_number();
     }
@@ -177,7 +163,7 @@ LASKIN_BUILTIN_WORD(w_sum)
   {
     auto sum = vec[0].as_number();
 
-    for (value::vector_container::size_type i = 1; i < size; ++i)
+    for (vector::size_type i = 1; i < size; ++i)
     {
       sum = sum + vec[i].as_number();
     }
@@ -215,7 +201,7 @@ LASKIN_BUILTIN_WORD(w_map)
 {
   const auto vec = context.pop().as_vector();
   const auto quote = context.pop().as_quote();
-  value::vector_container result;
+  vector result;
 
   result.reserve(vec.size());
   for (const auto& value : vec)
@@ -238,7 +224,7 @@ LASKIN_BUILTIN_WORD(w_filter)
 {
   const auto vec = context.pop().as_vector();
   const auto quote = context.pop().as_quote();
-  value::vector_container result;
+  vector result;
 
   for (const auto& value : vec)
   {
@@ -272,7 +258,7 @@ LASKIN_BUILTIN_WORD(w_reduce)
     throw error(error::type::range, U"Cannot reduce empty vector.");
   }
   result = vec[0];
-  for (value::vector_container::size_type i = 1; i < size; ++i)
+  for (vector::size_type i = 1; i < size; ++i)
   {
     context << result << vec[i];
     quote.call(context, out);
@@ -320,32 +306,21 @@ LASKIN_BUILTIN_WORD(w_append)
  */
 LASKIN_BUILTIN_WORD(w_insert)
 {
-  try
-  {
-    auto vec = context.pop().as_vector();
-    const auto size = vec.size();
-    const auto value = context.pop();
-    auto index = long(context.pop().as_number());
+  auto vec = context.pop().as_vector();
+  const auto size = vec.size();
+  const auto value = context.pop();
+  auto index = long(context.pop());
 
-    if (index < 0)
-    {
-      index += size;
-    }
-    if (!size || index < 0 || index >= static_cast<long>(size))
-    {
-      throw error(error::type::range, U"Vector index out of bounds.");
-    }
-    vec.insert(std::begin(vec) + index, 1, value);
-    context << vec;
-  }
-  catch (const std::underflow_error&)
+  if (index < 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    index += size;
   }
-  catch (const std::overflow_error&)
+  if (!size || index < 0 || index >= static_cast<long>(size))
   {
-    throw error(error::type::range, U"Numeric overflow.");
+    throw error(error::type::range, U"Vector index out of bounds.");
   }
+  vec.insert(std::begin(vec) + index, 1, value);
+  context << vec;
 }
 
 /**
@@ -355,9 +330,9 @@ LASKIN_BUILTIN_WORD(w_insert)
  */
 LASKIN_BUILTIN_WORD(w_reverse)
 {
-  const auto vector = context.pop().as_vector();
+  const auto vec = context.pop().as_vector();
 
-  context << value::make_vector(vector.rbegin(), vector.rend());
+  context << vector(std::rbegin(vec), std::rend(vec));
 }
 
 /**
@@ -375,17 +350,13 @@ LASKIN_BUILTIN_WORD(w_extract)
   }
 }
 
-static value::vector_container::size_type
-partition(
-  value::vector_container& vector,
-  value::vector_container::size_type low,
-  value::vector_container::size_type high
-)
+static vector::size_type
+partition(vector& vector, vector::size_type low, vector::size_type high)
 {
   const auto& pivot = vector[high];
   auto i = low - 1;
 
-  for (value::vector_container::size_type j = low; j <= high - 1; ++j)
+  for (vector::size_type j = low; j <= high - 1; ++j)
   {
     if (vector[j] < pivot)
     {
@@ -399,11 +370,7 @@ partition(
 }
 
 static void
-quicksort(
-  value::vector_container& vector,
-  value::vector_container::size_type low,
-  value::vector_container::size_type high
-)
+quicksort(vector& vector, vector::size_type low, vector::size_type high)
 {
   if (low < high)
   {
@@ -437,30 +404,19 @@ LASKIN_BUILTIN_WORD(w_sort)
  */
 LASKIN_BUILTIN_WORD(w_at)
 {
-  try
-  {
-    const auto vector = context.pop().as_vector();
-    const auto size = vector.size();
-    auto index = long(context.pop().as_number());
+  const auto vector = context.pop().as_vector();
+  const auto size = vector.size();
+  auto index = long(context.pop());
 
-    if (index < 0)
-    {
-      index += size;
-    }
-    if (!size || index < 0 || index >= static_cast<long>(size))
-    {
-      throw error(error::type::range, U"Vector index out of bounds.");
-    }
-    context << vector[index];
-  }
-  catch (const std::underflow_error&)
+  if (index < 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    index += size;
   }
-  catch (const std::overflow_error&)
+  if (!size || index < 0 || index >= static_cast<long>(size))
   {
-    throw error(error::type::range, U"Numeric overflow.");
+    throw error(error::type::range, U"Vector index out of bounds.");
   }
+  context << vector[index];
 }
 
 /**
@@ -473,32 +429,21 @@ LASKIN_BUILTIN_WORD(w_at)
  */
 LASKIN_BUILTIN_WORD(w_set)
 {
-  try
-  {
-    auto vector = context.pop().as_vector();
-    const auto size = vector.size();
-    auto index = long(context.pop().as_number());
-    const auto value = context.pop();
+  auto vector = context.pop().as_vector();
+  const auto size = vector.size();
+  auto index = long(context.pop());
+  const auto value = context.pop();
 
-    if (index < 0)
-    {
-      index += size;
-    }
-    if (!size || index < 0 || index >= static_cast<long>(size))
-    {
-      throw error(error::type::range, U"Vector index out of bounds.");
-    }
-    vector[index] = value;
-    context << vector;
-  }
-  catch (const std::underflow_error&)
+  if (index < 0)
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    index += size;
   }
-  catch (const std::overflow_error&)
+  if (!size || index < 0 || index >= static_cast<long>(size))
   {
-    throw error(error::type::range, U"Numeric overflow.");
+    throw error(error::type::range, U"Vector index out of bounds.");
   }
+  vector[index] = value;
+  context << vector;
 }
 
 /**
@@ -521,25 +466,14 @@ LASKIN_BUILTIN_WORD(w_to_time)
   {
     throw error(error::type::range, U"Time needs three values.");
   }
-  try
-  {
-    hour = long(vector[0].as_number());
-    minute = long(vector[1].as_number());
-    second = long(vector[2].as_number());
-  }
-  catch (const std::underflow_error&)
-  {
-    throw error(error::type::range, U"Numeric underflow.");
-  }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
-  if (!peelo::chrono::time::is_valid(hour, minute, second))
+  hour = long(vector[0]);
+  minute = long(vector[1]);
+  second = long(vector[2]);
+  if (!time::is_valid(hour, minute, second))
   {
     throw error(error::type::range, U"Invalid time.");
   }
-  context << value::make_time(peelo::chrono::time(hour, minute, second));
+  context << laskin::time(hour, minute, second);
 }
 
 /**
@@ -553,45 +487,34 @@ LASKIN_BUILTIN_WORD(w_to_time)
  */
 LASKIN_BUILTIN_WORD(w_to_date)
 {
-  try
-  {
-    const auto vector = context.pop().as_vector();
-    long day;
-    peelo::chrono::month month;
-    long year;
+  const auto vector = context.pop().as_vector();
+  long day;
+  month mon;
+  long year;
 
-    if (vector.size() != 3)
-    {
-      throw error(error::type::range, U"Date needs three values.");
-    }
-    year = long(vector[0].as_number());
-    if (vector[1].is(value::type::month))
-    {
-      month = vector[1].as_month();
-    } else {
-      const auto value = long(vector[1].as_number());
+  if (vector.size() != 3)
+  {
+    throw error(error::type::range, U"Date needs three values.");
+  }
+  year = long(vector[0]);
+  if (vector[1].is(value::type::month))
+  {
+    mon = vector[1].as_month();
+  } else {
+    const auto value = long(vector[1]);
 
-      if (value < 1 || value > 12)
-      {
-        throw error(error::type::range, U"Given month is out of range.");
-      }
-      month = static_cast<peelo::chrono::month>(value - 1);
-    }
-    day = long(vector[2].as_number());
-    if (!peelo::chrono::date::is_valid(year, month, day))
+    if (value < 1 || value > 12)
     {
-      throw error(error::type::range, U"Invalid date.");
+      throw error(error::type::range, U"Given month is out of range.");
     }
-    context << value::make_date(peelo::chrono::date(year, month, day));
+    mon = static_cast<month>(value - 1);
   }
-  catch (const std::underflow_error&)
+  day = long(vector[2]);
+  if (!date::is_valid(year, mon, day))
   {
-    throw error(error::type::range, U"Numeric underflow.");
+    throw error(error::type::range, U"Invalid date.");
   }
-  catch (const std::overflow_error&)
-  {
-    throw error(error::type::range, U"Numeric overflow.");
-  }
+  context << date(year, mon, day);
 }
 
 namespace laskin::api

--- a/laskin/src/api/weekday.cpp
+++ b/laskin/src/api/weekday.cpp
@@ -35,7 +35,7 @@ using namespace laskin;
  */
 LASKIN_BUILTIN_WORD(w_sunday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::sun);
+  context << weekday::sun;
 }
 
 /**
@@ -45,7 +45,7 @@ LASKIN_BUILTIN_WORD(w_sunday)
  */
 LASKIN_BUILTIN_WORD(w_monday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::mon);
+  context << weekday::mon;
 }
 
 /**
@@ -55,7 +55,7 @@ LASKIN_BUILTIN_WORD(w_monday)
  */
 LASKIN_BUILTIN_WORD(w_tuesday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::tue);
+  context << weekday::tue;
 }
 
 /**
@@ -65,7 +65,7 @@ LASKIN_BUILTIN_WORD(w_tuesday)
  */
 LASKIN_BUILTIN_WORD(w_wednesday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::wed);
+  context << weekday::wed;
 }
 
 /**
@@ -75,7 +75,7 @@ LASKIN_BUILTIN_WORD(w_wednesday)
  */
 LASKIN_BUILTIN_WORD(w_thursday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::thu);
+  context << weekday::thu;
 }
 
 /**
@@ -85,7 +85,7 @@ LASKIN_BUILTIN_WORD(w_thursday)
  */
 LASKIN_BUILTIN_WORD(w_friday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::fri);
+  context << weekday::fri;
 }
 
 /**
@@ -95,7 +95,7 @@ LASKIN_BUILTIN_WORD(w_friday)
  */
 LASKIN_BUILTIN_WORD(w_saturday)
 {
-  context << value::make_weekday(peelo::chrono::weekday::sat);
+  context << weekday::sat;
 }
 
 /**
@@ -107,10 +107,7 @@ LASKIN_BUILTIN_WORD(w_is_weekend)
 {
   const auto weekday = context.peek().as_weekday();
 
-  context << (
-    weekday == peelo::chrono::weekday::sat
-    || weekday == peelo::chrono::weekday::sun
-  );
+  context << (weekday == weekday::sat || weekday == weekday::sun);
 }
 
 /**

--- a/laskin/src/ast.cpp
+++ b/laskin/src/ast.cpp
@@ -64,7 +64,7 @@ namespace laskin
     std::ostream* out
   ) const
   {
-    value::vector_container container;
+    vector container;
 
     container.reserve(elements.size());
     for (const auto& element : elements)
@@ -72,7 +72,7 @@ namespace laskin
       container.push_back(element->eval(context, out));
     }
 
-    return value::make_vector(container);
+    return container;
   }
 
   bool
@@ -139,7 +139,7 @@ namespace laskin
     std::ostream* out
   ) const
   {
-    value::record_container resolved_properties;
+    record resolved_properties;
 
     for (const auto& property : properties)
     {
@@ -149,7 +149,7 @@ namespace laskin
       );
     }
 
-    return value::make_record(resolved_properties);
+    return resolved_properties;
   }
 
   bool

--- a/laskin/src/chrono.cpp
+++ b/laskin/src/chrono.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Rauli Laine
+ * Copyright (c) 2018-2026, Rauli Laine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,31 +31,31 @@
 
 namespace laskin
 {
-  static const std::unordered_map<std::u32string, peelo::chrono::month> month_mapping =
+  static const std::unordered_map<std::u32string, month> month_mapping =
   {
-      { U"january", peelo::chrono::month::jan },
-      { U"february", peelo::chrono::month::feb },
-      { U"march", peelo::chrono::month::mar },
-      { U"april", peelo::chrono::month::apr },
-      { U"may", peelo::chrono::month::may },
-      { U"june", peelo::chrono::month::jun },
-      { U"july", peelo::chrono::month::jul },
-      { U"august", peelo::chrono::month::aug },
-      { U"september", peelo::chrono::month::sep },
-      { U"october", peelo::chrono::month::oct },
-      { U"november", peelo::chrono::month::nov },
-      { U"december", peelo::chrono::month::dec }
+      { U"january", month::jan },
+      { U"february", month::feb },
+      { U"march", month::mar },
+      { U"april", month::apr },
+      { U"may", month::may },
+      { U"june", month::jun },
+      { U"july", month::jul },
+      { U"august", month::aug },
+      { U"september", month::sep },
+      { U"october", month::oct },
+      { U"november", month::nov },
+      { U"december", month::dec }
   };
 
-  static const std::unordered_map<std::u32string, peelo::chrono::weekday> weekday_mapping =
+  static const std::unordered_map<std::u32string, weekday> weekday_mapping =
   {
-    { U"sunday", peelo::chrono::weekday::sun },
-    { U"monday", peelo::chrono::weekday::mon },
-    { U"tuesday", peelo::chrono::weekday::tue },
-    { U"wednesday", peelo::chrono::weekday::wed },
-    { U"thursday", peelo::chrono::weekday::thu },
-    { U"friday", peelo::chrono::weekday::fri },
-    { U"saturday", peelo::chrono::weekday::sat }
+    { U"sunday", weekday::sun },
+    { U"monday", weekday::mon },
+    { U"tuesday", weekday::tue },
+    { U"wednesday", weekday::wed },
+    { U"thursday", weekday::thu },
+    { U"friday", weekday::fri },
+    { U"saturday", weekday::sat }
   };
 
   static inline bool is_digits(
@@ -69,7 +69,8 @@ namespace laskin
     const std::u32string::size_type
   );
 
-  bool is_date(const std::u32string& input)
+  bool
+  is_date(const std::u32string& input)
   {
     const auto length = input.length();
     std::u32string::size_type dash1;
@@ -85,7 +86,8 @@ namespace laskin
     );
   }
 
-  bool is_time(const std::u32string& input)
+  bool
+  is_time(const std::u32string& input)
   {
     return (
       input.length() == 8
@@ -97,25 +99,28 @@ namespace laskin
     );
   }
 
-  bool is_month(const std::u32string& input)
+  bool
+  is_month(const std::u32string& input)
   {
     return month_mapping.find(input) != std::end(month_mapping);
   }
 
-  bool is_weekday(const std::u32string& input)
+  bool
+  is_weekday(const std::u32string& input)
   {
     return weekday_mapping.find(input) != std::end(weekday_mapping);
   }
 
-  peelo::chrono::date parse_date(const std::u32string& input)
+  date
+  parse_date(const std::u32string& input)
   {
     const auto length = input.length();
     std::u32string::size_type dash1;
     std::u32string::size_type dash2;
     int year;
-    int month;
+    int month_int;
     int day;
-    peelo::chrono::month converted_month;
+    month converted_month;
 
     if (length < 5
         || (dash1 = input.find('-')) == std::u32string::npos
@@ -131,24 +136,25 @@ namespace laskin
     }
 
     year = to_integer(input, 0, dash1);
-    month = to_integer(input, dash1 + 1, dash2);
+    month_int = to_integer(input, dash1 + 1, dash2);
     day = to_integer(input, dash2 + 1, length);
 
-    if (month < 1 || month > 12)
+    if (month_int < 1 || month_int > 12)
     {
       throw error(error::type::range, U"Given month is out of range.");
     }
-    converted_month = static_cast<peelo::chrono::month>(month - 1);
+    converted_month = static_cast<month>(month_int - 1);
 
-    if (!peelo::chrono::date::is_valid(year, converted_month, day))
+    if (!date::is_valid(year, converted_month, day))
     {
       throw error(error::type::range, U"Given date literal is out of range.");
     }
 
-    return peelo::chrono::date(year, converted_month, day);
+    return date(year, converted_month, day);
   }
 
-  peelo::chrono::time parse_time(const std::u32string& input)
+  time
+  parse_time(const std::u32string& input)
   {
     int hour;
     int minute;
@@ -171,15 +177,16 @@ namespace laskin
     minute = to_integer(input, 3, 5);
     second = to_integer(input, 6, 8);
 
-    if (!peelo::chrono::time::is_valid(hour, minute, second))
+    if (!time::is_valid(hour, minute, second))
     {
       throw error(error::type::range, U"Given time value is out of range.");
     }
 
-    return peelo::chrono::time(hour, minute, second);
+    return time(hour, minute, second);
   }
 
-  peelo::chrono::month parse_month(const std::u32string& input)
+  month
+  parse_month(const std::u32string& input)
   {
     const auto entry = month_mapping.find(input);
 
@@ -191,7 +198,8 @@ namespace laskin
     return entry->second;
   }
 
-  peelo::chrono::weekday parse_weekday(const std::u32string& input)
+  weekday
+  parse_weekday(const std::u32string& input)
   {
     const auto entry = weekday_mapping.find(input);
 
@@ -203,9 +211,12 @@ namespace laskin
     return entry->second;
   }
 
-  static bool is_digits(const std::u32string& input,
-                        const std::u32string::size_type from,
-                        const std::u32string::size_type to)
+  static bool
+  is_digits(
+    const std::u32string& input,
+    const std::u32string::size_type from,
+    const std::u32string::size_type to
+  )
   {
     if (to - from == 0)
     {
@@ -222,9 +233,12 @@ namespace laskin
     return true;
   }
 
-  static int to_integer(const std::u32string& input,
-                        const std::u32string::size_type from,
-                        const std::u32string::size_type to)
+  static int
+  to_integer(
+    const std::u32string& input,
+    const std::u32string::size_type from,
+    const std::u32string::size_type to
+  )
   {
     static const auto div = INT_MAX / 10;
     static const auto rem = INT_MAX % 10;

--- a/laskin/src/context.cpp
+++ b/laskin/src/context.cpp
@@ -145,21 +145,21 @@ namespace laskin
       }
     }
 
-    if (peelo::number::is_valid(id))
+    if (number::is_valid(id))
     {
-      data.push_back(value::make_number(id));
+      data.push_back(value::parse_number(id));
       return;
     }
 
     if (is_date(id))
     {
-      data.push_back(value::make_date(id));
+      data.push_back(parse_date(id));
       return;
     }
 
     if (is_time(id))
     {
-      data.push_back(value::make_time(id));
+      data.push_back(parse_time(id));
       return;
     }
 
@@ -187,12 +187,12 @@ namespace laskin
   {
     if (id == U"true")
     {
-      return value::make_boolean(true);
+      return true;
     }
 
     if (id == U"false")
     {
-      return value::make_boolean(false);
+      return false;
     }
 
     if (id == U"drop")
@@ -200,29 +200,29 @@ namespace laskin
       return pop();
     }
 
-    if (peelo::number::is_valid(id))
+    if (number::is_valid(id))
     {
-      return value::make_number(id);
+      return value::parse_number(id);
     }
 
     if (is_date(id))
     {
-      return value::make_date(id);
+      return parse_date(id);
     }
 
     if (is_time(id))
     {
-      return value::make_time(id);
+      return parse_time(id);
     }
 
     if (is_month(id))
     {
-      return value::make_month(id);
+      return parse_month(id);
     }
 
     if (is_weekday(id))
     {
-      return value::make_weekday(id);
+      return parse_weekday(id);
     }
 
     if (default_callback)
@@ -266,181 +266,12 @@ namespace laskin
     throw error(error::type::range, U"Stack underflow.");
   }
 
-  void
-  context::push(const class value& value)
-  {
-    data.push_back(value);
-  }
-
-  void
-  context::clear()
-  {
-    data.clear();
-  }
-
-  context&
-  context::operator<<(const class value& value)
-  {
-    push(value);
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(bool value)
-  {
-    push(value::make_boolean(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const peelo::number& value)
-  {
-    push(value::make_number(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(double value)
-  {
-    push(value::make_number(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(int value)
-  {
-    push(value::make_number(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const std::u32string& value)
-  {
-    push(value::make_string(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const std::string& value)
-  {
-    using peelo::unicode::encoding::utf8::decode;
-
-    push(value::make_string(decode(value)));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const quote& value)
-  {
-    push(value::make_quote(value));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const value::vector_container& elements)
-  {
-    push(value::make_vector(elements));
-
-    return *this;
-  }
-
-  context&
-  context::operator<<(const value::record_container& properties)
-  {
-    push(value::make_record(properties));
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(class value& value)
-  {
-    value = pop();
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(bool& value)
-  {
-    value = pop().as_boolean();
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(peelo::number& value)
-  {
-    value = pop().as_number();
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(double& value)
-  {
-    try
-    {
-      value = double(pop().as_number());
-    }
-    catch (const std::underflow_error&)
-    {
-      throw error(error::type::range, U"Numeric value too small.");
-    }
-    catch (const std::overflow_error&)
-    {
-      throw error(error::type::range, U"Numeric value too large.");
-    }
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(std::u32string& value)
-  {
-    value = pop().as_string();
-
-    return *this;
-  }
-
   context&
   context::operator>>(std::string& value)
   {
     using peelo::unicode::encoding::utf8::encode;
 
     value = encode(pop().as_string());
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(quote& value)
-  {
-    value = pop().as_quote();
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(value::vector_container& elements)
-  {
-    elements = pop().as_vector();
-
-    return *this;
-  }
-
-  context&
-  context::operator>>(value::record_container& properties)
-  {
-    properties = pop().as_record();
 
     return *this;
   }
@@ -453,7 +284,7 @@ namespace laskin
   {
     for (const auto& word : definition)
     {
-      dictionary[word.first] = value::make_quote(quote(word.second));
+      dictionary[word.first] = word.second;
     }
   }
 }

--- a/laskin/src/operator/add.cpp
+++ b/laskin/src/operator/add.cpp
@@ -29,56 +29,47 @@
 namespace laskin
 {
   static inline value
-  add_number(const peelo::number& a, const peelo::number& b)
+  add_number(const number& a, const number& b)
   {
-    return value::make_number(a + b);
+    return a + b;
   }
 
   static value
-  add_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  add_vector(const vector& a, const vector& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
     if (size != b.size())
     {
       throw error(error::type::range, U"Vector length mismatch.");
     }
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] += b[i];
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static value
-  add_record(
-    const value::record_container& a,
-    const value::record_container& b
-  )
+  add_record(const record& a, const record& b)
   {
-    value::record_container result(a);
+    record result(a);
 
     for (const auto& property : b)
     {
       result[property.first] = property.second;
     }
 
-    return value::make_record(result);
+    return result;
   }
 
   static value
-  add_number_to_vector(
-    const value::vector_container& a,
-    const value& b
-  )
+  add_number_to_vector(const vector& a, const value& b)
   {
     const auto size = a.size();
-    value::vector_container result;
+    vector result;
 
     result.reserve(size);
     for (const auto& value : a)
@@ -86,21 +77,21 @@ namespace laskin
       result.push_back(value + b);
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static inline value
   add_string(const std::u32string& a, const std::u32string& b)
   {
-    return value::make_string(a + b);
+    return a + b;
   }
 
   static value
-  add_month(peelo::chrono::month a, const peelo::number& b)
+  add_month(month a, const value& b)
   {
     long delta;
 
-    if (b.measurement_unit())
+    if (b.as_number().measurement_unit())
     {
       throw error(
         error::type::type,
@@ -110,15 +101,15 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_month(a + delta);
+    return a + delta;
   }
 
   static value
-  add_weekday(peelo::chrono::weekday a, const peelo::number& b)
+  add_weekday(weekday a, const value& b)
   {
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
       if (!unit->symbol.compare("d"))
       {
@@ -133,15 +124,15 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_weekday(a + delta);
+    return a + delta;
   }
 
   static value
-  add_date(const peelo::chrono::date& a, const peelo::number& b)
+  add_date(const date& a, const value& b)
   {
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
       if (!unit->symbol.compare("d"))
       {
@@ -156,42 +147,47 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_date(a + delta);
+    return a + delta;
   }
 
   static value
-  add_time(const peelo::chrono::time& a, const peelo::number& b)
+  add_time(const time& a, const value& b)
   {
+    using peelo::chrono::duration;
+
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
+      duration::value_type multiplier;
+
       if (!unit->symbol.compare("s"))
       {
-        delta = long(b);
+        multiplier = 1;
       }
       else if (!unit->symbol.compare("min"))
       {
-        delta = long(b) * peelo::chrono::duration::minutes_per_hour;
+        multiplier = duration::minutes_per_hour;
       }
       else if (!unit->symbol.compare("h"))
       {
-        delta = long(b) * peelo::chrono::duration::seconds_per_hour;
+        multiplier = duration::seconds_per_hour;
       }
       else if (!unit->symbol.compare("d"))
       {
-        delta = long(b) * peelo::chrono::duration::seconds_per_day;
+        multiplier = duration::seconds_per_day;
       } else {
         throw error(
           error::type::type,
           U"Cannot add number to time."
         );
       }
+      delta = long(b) * multiplier;
     } else {
       delta = long(b);
     }
 
-    return value::make_time(a + delta);
+    return a + delta;
   }
 
   value
@@ -224,16 +220,16 @@ namespace laskin
         switch (m_type)
         {
           case type::month:
-            return add_month(m_value_month, *that.m_value_number);
+            return add_month(m_value_month, that);
 
           case type::weekday:
-            return add_weekday(m_value_weekday, *that.m_value_number);
+            return add_weekday(m_value_weekday, that);
 
           case type::date:
-            return add_date(*m_value_date, *that.m_value_number);
+            return add_date(*m_value_date, that);
 
           case type::time:
-            return add_time(*m_value_time, *that.m_value_number);
+            return add_time(*m_value_time, that);
 
           case type::vector:
             return add_number_to_vector(*m_value_vector, that);
@@ -243,15 +239,7 @@ namespace laskin
         }
       }
     }
-    catch (const std::underflow_error&)
-    {
-      throw error(error::type::range, U"Numeric underflow.");
-    }
-    catch (const std::overflow_error&)
-    {
-      throw error(error::type::range, U"Numeric overflow.");
-    }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/operator/compare.cpp
+++ b/laskin/src/operator/compare.cpp
@@ -29,7 +29,7 @@
 namespace laskin
 {
   static inline int
-  compare_number(const peelo::number& a, const peelo::number& b)
+  compare_number(const number& a, const number& b)
   {
     return a.compare(b);
   }
@@ -41,16 +41,13 @@ namespace laskin
   }
 
   static int
-  compare_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  compare_vector(const vector& a, const vector& b)
   {
     const auto size_a = a.size();
     const auto size_b = b.size();
     const auto min_size = std::min(size_a, size_b);
 
-    for (value::vector_container::size_type i = 0; i < min_size; ++i)
+    for (vector::size_type i = 0; i < min_size; ++i)
     {
       const auto cmp = a[i].compare(b[i]);
 
@@ -64,25 +61,25 @@ namespace laskin
   }
 
   static inline int
-  compare_month(peelo::chrono::month a, peelo::chrono::month b)
+  compare_month(month a, month b)
   {
     return a > b ? 1 : a < b ? -1 : 0;
   }
 
   static inline int
-  compare_weekday(peelo::chrono::weekday a, peelo::chrono::weekday b)
+  compare_weekday(weekday a, weekday b)
   {
     return a > b ? 1 : a < b ? -1 : 0;
   }
 
   static inline int
-  compare_date(const peelo::chrono::date& a, const peelo::chrono::date& b)
+  compare_date(const date& a, const date& b)
   {
     return a.compare(b);
   }
 
   static inline int
-  compare_time(const peelo::chrono::time& a, const peelo::chrono::time& b)
+  compare_time(const time& a, const time& b)
   {
     return a.compare(b);
   }
@@ -122,7 +119,7 @@ namespace laskin
         }
       }
     }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/operator/divide.cpp
+++ b/laskin/src/operator/divide.cpp
@@ -29,46 +29,41 @@
 namespace laskin
 {
   static inline value
-  divide_number(const peelo::number& a, const peelo::number& b)
+  divide_number(const number& a, const number& b)
   {
-    return value::make_number(a / b);
+    return a / b;
   }
 
   static value
-  divide_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  divide_vector(const vector& a, const vector& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
     if (size != b.size())
     {
       throw error(error::type::range, U"Vector length mismatch.");
     }
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] /= b[i];
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static value
-  divide_number_from_vector(
-    const value::vector_container& a,
-    const value& b)
+  divide_number_from_vector(const vector& a, const value& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] /= b;
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   value
@@ -102,7 +97,7 @@ namespace laskin
         }
       }
     }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/operator/equals.cpp
+++ b/laskin/src/operator/equals.cpp
@@ -35,16 +35,13 @@ namespace laskin
   }
 
   static inline bool
-  equals_number(const peelo::number& a, const peelo::number& b)
+  equals_number(const number& a, const number& b)
   {
     return a == b;
   }
 
   static bool
-  equals_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  equals_vector(const vector& a, const vector& b)
   {
     const auto size = a.size();
 
@@ -52,7 +49,7 @@ namespace laskin
     {
       return false;
     }
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       if (a[i] != b[i])
       {
@@ -64,10 +61,7 @@ namespace laskin
   }
 
   static bool
-  equals_record(
-    const value::record_container& a,
-    const value::record_container& b
-  )
+  equals_record(const record& a, const record& b)
   {
     if (a.size() != b.size())
     {
@@ -97,25 +91,25 @@ namespace laskin
   }
 
   static inline bool
-  equals_month(peelo::chrono::month a, peelo::chrono::month b)
+  equals_month(month a, month b)
   {
     return a == b;
   }
 
   static inline bool
-  equals_weekday(peelo::chrono::weekday a, peelo::chrono::weekday b)
+  equals_weekday(weekday a, weekday b)
   {
     return a == b;
   }
 
   static inline bool
-  equals_date(const peelo::chrono::date& a, const peelo::chrono::date& b)
+  equals_date(const date& a, const date& b)
   {
     return a == b;
   }
 
   static inline bool
-  equals_time(const peelo::chrono::time& a, const peelo::chrono::time& b)
+  equals_time(const time& a, const time& b)
   {
     return a == b;
   }

--- a/laskin/src/operator/modulo.cpp
+++ b/laskin/src/operator/modulo.cpp
@@ -29,46 +29,41 @@
 namespace laskin
 {
   static inline value
-  modulo_number(const peelo::number& a, const peelo::number& b)
+  modulo_number(const number& a, const number& b)
   {
-    return value::make_number(a % b);
+    return a % b;
   }
 
   static value
-  modulo_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  modulo_vector(const vector& a, const vector& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
     if (size != b.size())
     {
       throw error(error::type::range, U"Vector length mismatch.");
     }
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] %= b[i];
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static value
-  modulo_number_from_vector(
-    const value::vector_container& a,
-    const value& b)
+  modulo_number_from_vector(const vector& a, const value& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] %= b;
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   value
@@ -102,7 +97,7 @@ namespace laskin
         }
       }
     }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/operator/multiply.cpp
+++ b/laskin/src/operator/multiply.cpp
@@ -29,40 +29,34 @@
 namespace laskin
 {
   static inline value
-  multiply_number(const peelo::number& a, const peelo::number& b)
+  multiply_number(const number& a, const number& b)
   {
-    return value::make_number(a * b);
+    return a * b;
   }
 
   static value
-  multiply_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
-  )
+  multiply_vector(const vector& a, const vector& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
     if (size != b.size())
     {
       throw error(error::type::range, U"Vector length mismatch.");
     }
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] *= b[i];
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static value
-  multiply_number_with_vector(
-    const value::vector_container& a,
-    const value& b
-  )
+  multiply_number_with_vector(const vector& a, const value& b)
   {
     const auto size = a.size();
-    value::vector_container result;
+    vector result;
 
     result.reserve(size);
     for (const auto& value : a)
@@ -70,7 +64,7 @@ namespace laskin
       result.push_back(value * b);
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   value
@@ -104,7 +98,7 @@ namespace laskin
         }
       }
     }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/operator/substract.cpp
+++ b/laskin/src/operator/substract.cpp
@@ -30,40 +30,37 @@
 namespace laskin
 {
   static inline value
-  substract_number(const peelo::number& a, const peelo::number& b)
+  substract_number(const number& a, const number& b)
   {
-    return value::make_number(a - b);
+    return a - b;
   }
 
   static value
   substract_vector(
-    const value::vector_container& a,
-    const value::vector_container& b
+    const vector& a,
+    const vector& b
   )
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
     if (size != b.size())
     {
       throw error(error::type::range, U"Vector length mismatch.");
     }
     result.reserve(size);
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] -= b[i];
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static value
-  substract_record(
-    const value::record_container& a,
-    const value::record_container& b
-  )
+  substract_record(const record& a, const record& b)
   {
-    value::record_container result(a);
+    record result(a);
 
     for (const auto& property : b)
     {
@@ -75,47 +72,44 @@ namespace laskin
       }
     }
 
-    return value::make_record(result);
+    return result;
   }
 
   static value
-  substract_number_from_vector(
-    const value::vector_container& a,
-    const value& b
-  )
+  substract_number_from_vector(const vector& a, const value& b)
   {
     const auto size = a.size();
-    value::vector_container result(a);
+    vector result(a);
 
-    for (value::vector_container::size_type i = 0; i < size; ++i)
+    for (vector::size_type i = 0; i < size; ++i)
     {
       result[i] -= b;
     }
 
-    return value::make_vector(result);
+    return result;
   }
 
   static inline value
-  substract_date(const peelo::chrono::date& a, const peelo::chrono::date& b)
+  substract_date(const date& a, const date& b)
   {
-    return value::make_number((a - b).days(), peelo::number::unit::day);
+    return number((a - b).days(), number::unit::day);
   }
 
   static inline value
-  substract_time(const peelo::chrono::time& a, const peelo::chrono::time& b)
+  substract_time(const time& a, const time& b)
   {
-    return value::make_number(
+    return number(
       utils::time_as_seconds(a) - utils::time_as_seconds(b),
-      peelo::number::unit::second
+      number::unit::second
     );
   }
 
   static value
-  substract_month(peelo::chrono::month a, const peelo::number& b)
+  substract_month(month a, const value& b)
   {
     long delta;
 
-    if (b.measurement_unit())
+    if (b.as_number().measurement_unit())
     {
       throw error(
         error::type::type,
@@ -125,15 +119,15 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_month(a - delta);
+    return a - delta;
   }
 
   static value
-  substract_weekday(peelo::chrono::weekday a, const peelo::number& b)
+  substract_weekday(weekday a, const value& b)
   {
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
       if (!unit->symbol.compare("d"))
       {
@@ -148,15 +142,15 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_weekday(a - delta);
+    return a - delta;
   }
 
   static value
-  substract_date(const peelo::chrono::date& a, const peelo::number& b)
+  substract_date(const date& a, const value& b)
   {
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
       if (!unit->symbol.compare("d"))
       {
@@ -171,42 +165,47 @@ namespace laskin
       delta = long(b);
     }
 
-    return value::make_date(a - delta);
+    return a - delta;
   }
 
   static value
-  substract_time(const peelo::chrono::time& a, const peelo::number& b)
+  substract_time(const time& a, const value& b)
   {
+    using peelo::chrono::duration;
+
     long delta;
 
-    if (const auto& unit = b.measurement_unit())
+    if (const auto& unit = b.as_number().measurement_unit())
     {
+      duration::value_type multiplier;
+
       if (!unit->symbol.compare("s"))
       {
-        delta = long(b);
+        multiplier = 1;
       }
       else if (!unit->symbol.compare("min"))
       {
-        delta = long(b) * peelo::chrono::duration::minutes_per_hour;
+        multiplier = duration::minutes_per_hour;
       }
       else if (!unit->symbol.compare("h"))
       {
-        delta = long(b) * peelo::chrono::duration::seconds_per_hour;
+        multiplier = duration::seconds_per_hour;
       }
       else if (!unit->symbol.compare("d"))
       {
-        delta = long(b) * peelo::chrono::duration::seconds_per_day;
+        multiplier = duration::seconds_per_day;
       } else {
         throw error(
           error::type::type,
           U"Cannot substract number to time."
         );
       }
+      delta = long(b) * multiplier;
     } else {
       delta = long(b);
     }
 
-    return value::make_time(a - delta);
+    return a - delta;
   }
 
   value
@@ -242,16 +241,16 @@ namespace laskin
         switch (m_type)
         {
           case type::month:
-            return substract_month(m_value_month, *that.m_value_number);
+            return substract_month(m_value_month, that);
 
           case type::weekday:
-            return substract_weekday(m_value_weekday, *that.m_value_number);
+            return substract_weekday(m_value_weekday, that);
 
           case type::date:
-            return substract_date(*m_value_date, *that.m_value_number);
+            return substract_date(*m_value_date, that);
 
           case type::time:
-            return substract_time(*m_value_time, *that.m_value_number);
+            return substract_time(*m_value_time, that);
 
           case type::vector:
             return substract_number_from_vector(*m_value_vector, that);
@@ -261,15 +260,7 @@ namespace laskin
         }
       }
     }
-    catch (const std::underflow_error&)
-    {
-      throw error(error::type::range, U"Numeric underflow.");
-    }
-    catch (const std::overflow_error&)
-    {
-      throw error(error::type::range, U"Numeric overflow.");
-    }
-    catch (const peelo::number::unit_error& e)
+    catch (const number::unit_error& e)
     {
       throw error(error::type::unit, e.what());
     }

--- a/laskin/src/parser.cpp
+++ b/laskin/src/parser.cpp
@@ -323,10 +323,7 @@ namespace laskin
     const auto position = state.position;
     const auto value = parse_string(state);
 
-    return std::make_shared<node::literal>(
-      value::make_string(value),
-      position
-    );
+    return std::make_shared<node::literal>(value, position);
   }
 
   static std::shared_ptr<node::vector_literal>
@@ -508,7 +505,7 @@ namespace laskin
       }
     }
 
-    return std::make_shared<node::literal>(value::make_quote(nodes), position);
+    return std::make_shared<node::literal>(quote(nodes), position);
   }
 
   static std::u32string

--- a/laskin/src/utils.cpp
+++ b/laskin/src/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Rauli Laine
+ * Copyright (c) 2018-2026, Rauli Laine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,11 +29,12 @@
 
 namespace laskin::utils
 {
-  std::int64_t time_as_seconds(const peelo::chrono::time& time)
+  std::int64_t
+  time_as_seconds(const time& value)
   {
-    const auto hour = static_cast<std::int64_t>(time.hour());
-    const auto minute = static_cast<std::int64_t>(time.minute());
-    auto second = static_cast<std::int64_t>(time.second());
+    const auto hour = static_cast<std::int64_t>(value.hour());
+    const auto minute = static_cast<std::int64_t>(value.minute());
+    auto second = static_cast<std::int64_t>(value.second());
 
     if (minute > 0)
     {
@@ -47,7 +48,8 @@ namespace laskin::utils
     return second;
   }
 
-  std::u32string escape_string(const std::u32string& str)
+  std::u32string
+  escape_string(const std::u32string& str)
   {
     std::u32string result;
 

--- a/laskin/src/value.cpp
+++ b/laskin/src/value.cpp
@@ -36,219 +36,79 @@
 namespace laskin
 {
   value
-  value::make_boolean(bool value)
+  value::parse_number(const std::u32string& input)
   {
-    class value instance;
-
-    instance.m_value_boolean = value;
-
-    return instance;
-  }
-
-  value
-  value::make_number(const peelo::number& value)
-  {
-    class value instance;
-
-    instance.m_type = type::number;
-    instance.m_value_number = new peelo::number(value);
-
-    return instance;
-  }
-
-  value
-  value::make_number(
-    int value,
-    const peelo::number::unit_type& unit
-  )
-  {
-    return make_number(static_cast<std::int64_t>(value), unit);
-  }
-
-  value
-  value::make_number(
-    std::int64_t value,
-    const peelo::number::unit_type& unit
-  )
-  {
-    class value instance;
-
-    instance.m_type = type::number;
-    instance.m_value_number = new peelo::number(value, unit);
-
-    return instance;
-  }
-
-  value
-  value::make_number(
-    double value,
-    const peelo::number::unit_type& unit
-  )
-  {
-    class value instance;
-
-    instance.m_type = type::number;
-    instance.m_value_number = new peelo::number(value, unit);
-
-    return instance;
-  }
-
-  value
-  value::make_number(const std::u32string& input)
-  {
-    value instance;
-
     try
     {
-      instance.m_value_number = new peelo::number(peelo::number::parse(input));
-      instance.m_type = type::number;
+      return number::parse(input);
     }
     catch (const std::invalid_argument&)
     {
       throw error(error::type::range, U"Input does not contain valid number.");
     }
-
-    return instance;
-  }
-
-  value
-  value::make_vector(const vector_container& elements)
-  {
-    class value instance;
-
-    instance.m_type = type::vector;
-    instance.m_value_vector = new vector_container(elements);
-
-    return instance;
-  }
-
-  value
-  value::make_record(const record_container& properties)
-  {
-    class value instance;
-
-    instance.m_type = type::record;
-    instance.m_value_record = new record_container(properties);
-
-    return instance;
-  }
-
-  value
-  value::make_string(const std::u32string& string)
-  {
-    value instance;
-
-    instance.m_type = type::string;
-    instance.m_value_string = new std::u32string(string);
-
-    return instance;
-  }
-
-  value
-  value::make_quote(const class quote& quote)
-  {
-    class value instance;
-
-    instance.m_type = type::quote;
-    instance.m_value_quote = new class quote(quote);
-
-    return instance;
-  }
-
-  value
-  value::make_quote(const quote::node_container& nodes)
-  {
-    class value instance;
-
-    instance.m_type = type::quote;
-    instance.m_value_quote = new class quote(nodes);
-
-    return instance;
-  }
-
-  value
-  value::make_month(peelo::chrono::month month)
-  {
-    value instance;
-
-    instance.m_type = type::month;
-    instance.m_value_month = month;
-
-    return instance;
-  }
-
-  value
-  value::make_month(const std::u32string& month)
-  {
-    return make_month(parse_month(month));
-  }
-
-  value
-  value::make_weekday(peelo::chrono::weekday weekday)
-  {
-    value instance;
-
-    instance.m_type = type::weekday;
-    instance.m_value_weekday = weekday;
-
-    return instance;
-  }
-
-  value
-  value::make_weekday(const std::u32string& weekday)
-  {
-    return make_weekday(parse_weekday(weekday));
-  }
-
-  value
-  value::make_date(const peelo::chrono::date& date)
-  {
-    value instance;
-
-    instance.m_type = type::date;
-    instance.m_value_date = new peelo::chrono::date(date);
-
-    return instance;
-  }
-
-  value
-  value::make_date(const std::u32string& input)
-  {
-    const auto date = parse_date(input);
-    value instance;
-
-    instance.m_type = type::date;
-    instance.m_value_date = new peelo::chrono::date(date);
-
-    return instance;
-  }
-
-  value
-  value::make_time(const peelo::chrono::time& time)
-  {
-    value instance;
-
-    instance.m_type = type::time;
-    instance.m_value_time = new peelo::chrono::time(time);
-
-    return instance;
-  }
-
-  value
-  value::make_time(const std::u32string& input)
-  {
-    const auto time = parse_time(input);
-    value instance;
-
-    instance.m_type = type::time;
-    instance.m_value_time = new peelo::chrono::time(time);
-
-    return instance;
   }
 
   value::value()
     : m_type(type::boolean)
     , m_value_boolean(false) {}
+
+  value::value(bool value)
+    : m_type(type::boolean)
+    , m_value_boolean(value) {}
+
+  value::value(const number& value)
+    : m_type(type::number)
+    , m_value_number(new number(value)) {}
+
+  value::value(int value)
+    : m_type(type::number)
+    , m_value_number(new number(value)) {}
+
+  value::value(long value)
+    : m_type(type::number)
+    , m_value_number(new number(value)) {}
+
+  value::value(double value)
+    : m_type(type::number)
+    , m_value_number(new number(value)) {}
+
+  value::value(const std::u32string& value)
+    : m_type(type::string)
+    , m_value_string(new std::u32string(value)) {}
+
+  value::value(const std::string& value)
+    : m_type(type::string)
+    , m_value_string(new std::u32string(
+        peelo::unicode::encoding::utf8::decode(value))
+      ) {}
+
+  value::value(const vector& elements)
+    : m_type(type::vector)
+    , m_value_vector(new vector(elements)) {}
+
+  value::value(const record& properties)
+    : m_type(type::record)
+    , m_value_record(new record(properties)) {}
+
+  value::value(const quote& value)
+    : m_type(type::quote)
+    , m_value_quote(new quote(value)) {}
+
+  value::value(const date& value)
+    : m_type(type::date)
+    , m_value_date(new date(value)) {}
+
+  value::value(const time& value)
+    : m_type(type::time)
+    , m_value_time(new time(value)) {}
+
+  value::value(month value)
+    : m_type(type::month)
+    , m_value_month(value) {}
+
+  value::value(weekday value)
+    : m_type(type::weekday)
+    , m_value_weekday(value) {}
 
   value::value(const value& that)
     : m_type(that.m_type)
@@ -260,11 +120,11 @@ namespace laskin
         break;
 
       case type::number:
-        m_value_number = new peelo::number(*that.m_value_number);
+        m_value_number = new number(*that.m_value_number);
         break;
 
       case type::vector:
-        m_value_vector = new vector_container(*that.m_value_vector);
+        m_value_vector = new vector(*that.m_value_vector);
         break;
 
       case type::string:
@@ -284,15 +144,15 @@ namespace laskin
         break;
 
       case type::date:
-        m_value_date = new peelo::chrono::date(*that.m_value_date);
+        m_value_date = new date(*that.m_value_date);
         break;
 
       case type::time:
-        m_value_time = new peelo::chrono::time(*that.m_value_time);
+        m_value_time = new time(*that.m_value_time);
         break;
 
       case type::record:
-        m_value_record = new record_container(*that.m_value_record);
+        m_value_record = new record(*that.m_value_record);
         break;
     }
   }
@@ -352,6 +212,148 @@ namespace laskin
   }
 
   value&
+  value::assign(bool value)
+  {
+    reset();
+    m_type = type::boolean;
+    m_value_boolean = value;
+
+    return *this;
+  }
+
+  value&
+  value::assign(const number& value)
+  {
+    reset();
+    m_type = type::number;
+    m_value_number = new number(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(int value)
+  {
+    reset();
+    m_type = type::number;
+    m_value_number = new number(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(long value)
+  {
+    reset();
+    m_type = type::number;
+    m_value_number = new number(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(double value)
+  {
+    reset();
+    m_type = type::number;
+    m_value_number = new number(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const std::u32string& value)
+  {
+    reset();
+    m_type = type::string;
+    m_value_string = new std::u32string(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const std::string& value)
+  {
+    using peelo::unicode::encoding::utf8::decode;
+
+    reset();
+    m_type = type::string;
+    m_value_string = new std::u32string(decode(value));
+
+    return *this;
+  }
+
+  value&
+  value::assign(const vector& elements)
+  {
+    reset();
+    m_type = type::vector;
+    m_value_vector = new vector(elements);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const record& properties)
+  {
+    reset();
+    m_type = type::record;
+    m_value_record = new record(properties);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const quote& value)
+  {
+    reset();
+    m_type = type::quote;
+    m_value_quote = new quote(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const date& value)
+  {
+    reset();
+    m_type = type::date;
+    m_value_date = new date(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(const time& value)
+  {
+    reset();
+    m_type = type::time;
+    m_value_time = new time(value);
+
+    return *this;
+  }
+
+  value&
+  value::assign(month value)
+  {
+    reset();
+    m_type = type::month;
+    m_value_month = value;
+
+    return *this;
+  }
+
+  value&
+  value::assign(weekday value)
+  {
+    reset();
+    m_type = type::weekday;
+    m_value_weekday = value;
+
+    return *this;
+  }
+
+  value&
   value::assign(const value& that)
   {
     if (this != &that)
@@ -364,11 +366,11 @@ namespace laskin
           break;
 
         case type::number:
-          m_value_number = new peelo::number(*that.m_value_number);
+          m_value_number = new number(*that.m_value_number);
           break;
 
         case type::vector:
-          m_value_vector = new vector_container(*that.m_value_vector);
+          m_value_vector = new vector(*that.m_value_vector);
           break;
 
         case type::string:
@@ -388,15 +390,15 @@ namespace laskin
           break;
 
         case type::date:
-          m_value_date = new peelo::chrono::date(*that.m_value_date);
+          m_value_date = new date(*that.m_value_date);
           break;
 
         case type::time:
-          m_value_time = new peelo::chrono::time(*that.m_value_time);
+          m_value_time = new time(*that.m_value_time);
           break;
 
         case type::record:
-          m_value_record = new record_container(*that.m_value_record);
+          m_value_record = new record(*that.m_value_record);
           break;
       }
     }
@@ -555,7 +557,7 @@ namespace laskin
     return m_value_boolean;
   }
 
-  const peelo::number&
+  const number&
   value::as_number() const
   {
     if (!is(type::number))
@@ -571,7 +573,7 @@ namespace laskin
     return *m_value_number;
   }
 
-  const value::vector_container&
+  const vector&
   value::as_vector() const
   {
     if (!is(type::vector))
@@ -587,7 +589,7 @@ namespace laskin
     return *m_value_vector;
   }
 
-  const value::record_container&
+  const record&
   value::as_record() const
   {
     if (!is(type::record))
@@ -635,7 +637,7 @@ namespace laskin
     return *m_value_quote;
   }
 
-  peelo::chrono::month
+  month
   value::as_month() const
   {
     if (!is(type::month))
@@ -651,7 +653,7 @@ namespace laskin
     return m_value_month;
   }
 
-  peelo::chrono::weekday
+  weekday
   value::as_weekday() const
   {
     if (!is(type::weekday))
@@ -667,7 +669,7 @@ namespace laskin
     return m_value_weekday;
   }
 
-  const peelo::chrono::date&
+  const date&
   value::as_date() const
   {
     if (!is(type::date))
@@ -683,7 +685,7 @@ namespace laskin
     return *m_value_date;
   }
 
-  const peelo::chrono::time&
+  const time&
   value::as_time() const
   {
     if (!is(type::time))
@@ -699,8 +701,40 @@ namespace laskin
     return *m_value_time;
   }
 
+  value::operator long() const
+  {
+    try
+    {
+      return long(as_number());
+    }
+    catch (const std::underflow_error&)
+    {
+      throw error(error::type::range, U"Numeric underflow.");
+    }
+    catch (const std::overflow_error&)
+    {
+      throw error(error::type::range, U"Numeric overflow.");
+    }
+  }
+
+  value::operator double() const
+  {
+    try
+    {
+      return double(as_number());
+    }
+    catch (const std::underflow_error&)
+    {
+      throw error(error::type::range, U"Numeric underflow.");
+    }
+    catch (const std::overflow_error&)
+    {
+      throw error(error::type::range, U"Numeric overflow.");
+    }
+  }
+
   static std::u32string
-  vector_to_string(const value::vector_container& elements)
+  vector_to_string(const vector& elements)
   {
     std::u32string result;
     bool first = true;
@@ -720,44 +754,44 @@ namespace laskin
   }
 
   static std::u32string
-  month_to_string(peelo::chrono::month month)
+  month_to_string(month value)
   {
-    switch (month)
+    switch (value)
     {
-      case peelo::chrono::month::jan:
+      case month::jan:
         return U"january";
 
-      case peelo::chrono::month::feb:
+      case month::feb:
         return U"february";
 
-      case peelo::chrono::month::mar:
+      case month::mar:
         return U"march";
 
-      case peelo::chrono::month::apr:
+      case month::apr:
         return U"april";
 
-      case peelo::chrono::month::may:
+      case month::may:
         return U"may";
 
-      case peelo::chrono::month::jun:
+      case month::jun:
         return U"june";
 
-      case peelo::chrono::month::jul:
+      case month::jul:
         return U"july";
 
-      case peelo::chrono::month::aug:
+      case month::aug:
         return U"august";
 
-      case peelo::chrono::month::sep:
+      case month::sep:
         return U"september";
 
-      case peelo::chrono::month::oct:
+      case month::oct:
         return U"october";
 
-      case peelo::chrono::month::nov:
+      case month::nov:
         return U"november";
 
-      case peelo::chrono::month::dec:
+      case month::dec:
         return U"december";
     }
 
@@ -765,29 +799,29 @@ namespace laskin
   }
 
   static std::u32string
-  weekday_to_string(peelo::chrono::weekday weekday)
+  weekday_to_string(weekday value)
   {
-    switch (weekday)
+    switch (value)
     {
-      case peelo::chrono::weekday::sun:
+      case weekday::sun:
         return U"sunday";
 
-      case peelo::chrono::weekday::mon:
+      case weekday::mon:
         return U"monday";
 
-      case peelo::chrono::weekday::tue:
+      case weekday::tue:
         return U"tuesday";
 
-      case peelo::chrono::weekday::wed:
+      case weekday::wed:
         return U"wednesday";
 
-      case peelo::chrono::weekday::thu:
+      case weekday::thu:
         return U"thursday";
 
-      case peelo::chrono::weekday::fri:
+      case weekday::fri:
         return U"friday";
 
-      case peelo::chrono::weekday::sat:
+      case weekday::sat:
         return U"saturday";
     }
 
@@ -795,11 +829,11 @@ namespace laskin
   }
 
   static std::u32string
-  date_to_string(const peelo::chrono::date& date)
+  date_to_string(const date& value)
   {
-    const auto year = date.year();
-    const auto month = date.month();
-    const auto day = date.day();
+    const auto year = value.year();
+    const auto month = value.month();
+    const auto day = value.day();
     char buffer[32];
     std::u32string result;
 
@@ -821,11 +855,11 @@ namespace laskin
   }
 
   static std::u32string
-  time_to_string(const peelo::chrono::time& time)
+  time_to_string(const time& value)
   {
-    const auto hour = time.hour();
-    const auto minute = time.minute();
-    const auto second = time.second();
+    const auto hour = value.hour();
+    const auto minute = value.minute();
+    const auto second = value.second();
     char buffer[9];
     std::u32string result;
 
@@ -847,7 +881,7 @@ namespace laskin
   }
 
   static std::u32string
-  record_to_string(const value::record_container& properties)
+  record_to_string(const record& properties)
   {
     std::u32string result;
     bool first = true;
@@ -908,7 +942,7 @@ namespace laskin
   }
 
   static std::u32string
-  vector_to_source(const value::vector_container& elements)
+  vector_to_source(const vector& elements)
   {
     std::u32string result;
     bool first = true;
@@ -930,7 +964,7 @@ namespace laskin
   }
 
   static std::u32string
-  record_to_source(const value::record_container& properties)
+  record_to_source(const record& properties)
   {
     std::u32string result;
     bool first = true;


### PR DESCRIPTION
For easier embedding to other C++ projects, redesign how the `value`
class works. Getting rid of static `make_*` methods also improves
performance.